### PR TITLE
agent_logs_payload: make json output compatible with what handle today

### DIFF
--- a/agent_logs_payload.proto
+++ b/agent_logs_payload.proto
@@ -19,9 +19,9 @@ message Log {
 
     // from config
     string service = 5;
-    string source = 6;
+    string source = 6 [json_name="ddsource"];
 
     // from config, container tags, ...
-    repeated string tags = 7;
+    repeated string tags = 7 [json_name="ddtags"];
 
 }


### PR DESCRIPTION
See https://docs.datadoghq.com/logs/?tab=ussite#from-a-custom-forwarder which
advertises the ddtags and ddsource fields.

The goal is to be able to: ```JsonFormat.printer().print(log)``` and have something that works in json.