### PR TITLE
Remove overridden zstd dependency to avoid transitive dep conflicts

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,11 +3,10 @@
 
 [[projects]]
   digest = "1:f3662169bf21f0406cdad064a592c5a052e8ba32f64a360d755544cd5a98dba8"
-  name = "github.com/DataDog/zstd.v0.5"
+  name = "github.com/DataDog/zstd"
   packages = ["."]
   pruneopts = ""
   revision = "2b373cbe6ac0c8e6960bbd18026ceb269eef89f5"
-  source = "github.com/DataDog/zstd"
 
 [[projects]]
   digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
@@ -52,7 +51,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
-    "github.com/DataDog/zstd.v0.5",
+    "github.com/DataDog/zstd",
     "github.com/gogo/protobuf/gogoproto",
     "github.com/gogo/protobuf/jsonpb",
     "github.com/gogo/protobuf/proto",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -3,6 +3,5 @@
   version = "=v1.0.0"
 
 [[constraint]]
-  name = "github.com/DataDog/zstd.v0.5"
-  source = "github.com/DataDog/zstd"
+  name = "github.com/DataDog/zstd"
   revision = "2b373cbe6ac0c8e6960bbd18026ceb269eef89f5"

--- a/process/message.go
+++ b/process/message.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"reflect"
 
-	zstd "github.com/DataDog/zstd.v0.5"
+	"github.com/DataDog/zstd"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 )


### PR DESCRIPTION
This allows the zstd dependency to be properly overridden by projects that depend on this one

