### PR TITLE
`go mod` hack to make protobuf dependencies work with go modules

### DIFF
--- a/proto/logs/logs.go
+++ b/proto/logs/logs.go
@@ -1,0 +1,3 @@
+package logs
+
+// this is a hack to make go module vendoring work

--- a/proto/metrics/metrics.go
+++ b/proto/metrics/metrics.go
@@ -1,0 +1,3 @@
+package metrics
+
+// this is a hack to make go module vendoring work

--- a/proto/process/agent.go
+++ b/proto/process/agent.go
@@ -1,0 +1,3 @@
+package agent
+
+// this is a hack to make go module vendoring work


### PR DESCRIPTION
This is a hack for `go mod` support. As this is a known issue the tool does not download and cache any directories that do not contain go files.