### PR TITLE
Use a proper version for mmh3 to better help resolve version conflicts

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -7,6 +7,7 @@
   packages = ["."]
   pruneopts = ""
   revision = "6574a4241c5250712174e75a1042b4595124889e"
+  version = "1.0.0"
 
 [[projects]]
   digest = "1:f3662169bf21f0406cdad064a592c5a052e8ba32f64a360d755544cd5a98dba8"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -8,4 +8,4 @@
 
 [[constraint]]
   name = "github.com/DataDog/mmh3"
-  revision = "6574a4241c5250712174e75a1042b4595124889e"
+  version = "^1.0.0"


### PR DESCRIPTION
This will allow projects that import this library as well as mmh3 to choose a different, but compatible, mmh3 version