### PR TITLE
Normalize tag names to lower case and remove duplicates for a given IP

### DIFF
--- a/process/dns_test.go
+++ b/process/dns_test.go
@@ -53,6 +53,19 @@ func TestV1EncodeDNS_NoNames(t *testing.T) {
 	assertDNSEqual(t, nil, buf, "10.128.99.240")
 }
 
+func TestV1EncodeDNS_MixedCaseNames(t *testing.T) {
+	dns := make(map[string]*DNSEntry)
+
+	dns["10.128.98.75"] = &DNSEntry{Names: []string{"k8s-pareNt1.uS1.sTaGing.dog", "K8S-Parent1.us1.staging.dog"}}
+	dns["10.128.99.240"] = &DNSEntry{Names: []string{"k8s-parent1.US1.staging.DOG"}}
+
+	encoder := NewV1DNSEncoder()
+	buf := encoder.Encode(dns)
+
+	assertDNSEqual(t, []string{"k8s-parent1.us1.staging.dog"}, buf, "10.128.98.75")
+	assertDNSEqual(t, []string{"k8s-parent1.us1.staging.dog"}, buf, "10.128.99.240")
+}
+
 func TestV1EncodeDNS_SampleData(t *testing.T) {
 	sampleFiles := []string{
 		"testdata/dns/samples.txt",


### PR DESCRIPTION
We noticed that some IPs were resolving to multiple DNS entries that only differed by their case: `[host.name.com, HoSt.nAMe.COM]`, for example are the same entry. This commit normalizes incoming DNS names by converting them all to lower case and removing any resulting duplicates