### PR TITLE
Extract encoded dns names

### DIFF
--- a/process/connections.go
+++ b/process/connections.go
@@ -32,3 +32,8 @@ func (m *CollectorConnections) GetDNS(addr *Addr) (string, []string) {
 func (m *CollectorConnections) IterateDNS(addr *Addr, cb func(i, total int, entry string) bool) {
 	iterateDNS(m.EncodedDNS, addr.Ip, cb)
 }
+
+// GetDNSNames returns all the DNS entries
+func (m *CollectorConnections) GetDNSNames() []string {
+	return getDNSNames(m.EncodedDNS)
+}

--- a/process/dns.go
+++ b/process/dns.go
@@ -19,6 +19,18 @@ func getDNS(buf []byte, ip string) (string, []string) {
 	return "", nil
 }
 
+func getNames(buf []byte) []string {
+	if len(buf) == 0 {
+		return nil
+	}
+
+	switch buf[0] {
+	case dnsVersion1:
+		return getNamesV1(buf)
+	}
+	return nil
+}
+
 func iterateDNS(buf []byte, ip string, cb func(i, total int, entry string) bool) {
 	if len(buf) == 0 || ip == "" {
 		return

--- a/process/dns.go
+++ b/process/dns.go
@@ -19,14 +19,14 @@ func getDNS(buf []byte, ip string) (string, []string) {
 	return "", nil
 }
 
-func getNames(buf []byte) []string {
+func getDNSNames(buf []byte) []string {
 	if len(buf) == 0 {
 		return nil
 	}
 
 	switch buf[0] {
 	case dnsVersion1:
-		return getNamesV1(buf)
+		return getDNSNamesV1(buf)
 	}
 	return nil
 }

--- a/process/dns_test.go
+++ b/process/dns_test.go
@@ -27,7 +27,7 @@ func TestV1EncodeDNS(t *testing.T) {
 	assertDNSEqual(t, []string{"app.datad0g.com"}, buf, "34.231.44.115")
 	assertDNSEqual(t, nil, buf, "134.231.44.115")
 	assertDNSEqual(t, nil, buf, "1.1.1.1")
-	assert.Equal(t, 3, len(getNames(buf)))
+	assert.Equal(t, 3, len(getDNSNames(buf)))
 }
 
 func TestV1EncodeDNS_Empty(t *testing.T) {
@@ -38,7 +38,7 @@ func TestV1EncodeDNS_Empty(t *testing.T) {
 
 	assert.Empty(t, buf)
 	assertDNSEqual(t, nil, buf, "1.1.1.1")
-	assert.Equal(t, 0, len(getNames(buf)))
+	assert.Equal(t, 0, len(getDNSNames(buf)))
 }
 
 func TestV1EncodeDNS_NoNames(t *testing.T) {
@@ -53,7 +53,7 @@ func TestV1EncodeDNS_NoNames(t *testing.T) {
 	assert.Empty(t, buf)
 	assertDNSEqual(t, nil, buf, "10.128.98.75")
 	assertDNSEqual(t, nil, buf, "10.128.99.240")
-	assert.Equal(t, 0, len(getNames(buf)))
+	assert.Equal(t, 0, len(getDNSNames(buf)))
 }
 
 func TestV1EncodeDNS_SampleData(t *testing.T) {

--- a/process/dns_test.go
+++ b/process/dns_test.go
@@ -27,6 +27,7 @@ func TestV1EncodeDNS(t *testing.T) {
 	assertDNSEqual(t, []string{"app.datad0g.com"}, buf, "34.231.44.115")
 	assertDNSEqual(t, nil, buf, "134.231.44.115")
 	assertDNSEqual(t, nil, buf, "1.1.1.1")
+	assert.Equal(t, 3, len(getNames(buf)))
 }
 
 func TestV1EncodeDNS_Empty(t *testing.T) {
@@ -37,6 +38,7 @@ func TestV1EncodeDNS_Empty(t *testing.T) {
 
 	assert.Empty(t, buf)
 	assertDNSEqual(t, nil, buf, "1.1.1.1")
+	assert.Equal(t, 0, len(getNames(buf)))
 }
 
 func TestV1EncodeDNS_NoNames(t *testing.T) {
@@ -51,6 +53,7 @@ func TestV1EncodeDNS_NoNames(t *testing.T) {
 	assert.Empty(t, buf)
 	assertDNSEqual(t, nil, buf, "10.128.98.75")
 	assertDNSEqual(t, nil, buf, "10.128.99.240")
+	assert.Equal(t, 0, len(getNames(buf)))
 }
 
 func TestV1EncodeDNS_SampleData(t *testing.T) {

--- a/process/dns_v1.go
+++ b/process/dns_v1.go
@@ -231,7 +231,7 @@ func getV1(buf []byte, ip string) (string, []string) {
 	return first, names
 }
 
-func getNamesV1(buf []byte) []string {
+func getDNSNamesV1(buf []byte) []string {
 	var names []string
 	// skip the preamble
 	index := dns1Version1PreambleLength

--- a/process/dns_v1.go
+++ b/process/dns_v1.go
@@ -231,6 +231,27 @@ func getV1(buf []byte, ip string) (string, []string) {
 	return first, names
 }
 
+func getNamesV1(buf []byte) []string {
+	var names []string
+	// skip the preamble
+	index := dns1Version1PreambleLength
+
+	_, bytesRead := binary.Uvarint(buf[index:])
+	index += bytesRead
+	nameBufferLen, bytesRead := binary.Uvarint(buf[index:])
+
+	start := len(buf) - int(nameBufferLen)
+	nameBuffer := buf[start:]
+
+	for namePosition := 0; namePosition < len(nameBuffer); {
+		nameLength, bytesReadForName := binary.Uvarint(nameBuffer[namePosition:])
+		namePosition += bytesReadForName
+		name := string(nameBuffer[namePosition : namePosition+int(nameLength)])
+		names = append(names, name)
+		namePosition += int(nameLength)
+	}
+	return names
+}
 func iterateDNSV1(buf []byte, ip string, cb func(i, total int, entry string) bool) {
 	// Read overview:
 	//	Compute the target bucket for the given ip


### PR DESCRIPTION
This PR adds a function to extract encoded DNS names from the `CollectorConnections` payload.
