### PR TITLE
Add UnsafeIterateDNS

### DIFF
--- a/process/dns.go
+++ b/process/dns.go
@@ -43,3 +43,16 @@ func IterateDNS(buf []byte, ip string, cb func(i, total int, entry string) bool)
 		iterateDNSV1(buf, ip, cb)
 	}
 }
+
+// UnsafeIterateDNS invokes the callback function for each DNS entry for the given IP in the given buffer.
+// Each entry is a the slice from the overall buffer.  It should be copied before use
+func UnsafeIterateDNS(buf []byte, ip string, cb func(i, total int, entry []byte) bool) {
+	if len(buf) == 0 || ip == "" {
+		return
+	}
+
+	switch buf[0] {
+	case dnsVersion1:
+		unsafeIterateDNSV1(buf, ip, cb)
+	}
+}

--- a/process/dns_test.go
+++ b/process/dns_test.go
@@ -208,6 +208,12 @@ func assertDNSEqual(t *testing.T, expected []string, buf []byte, key string) {
 		return true
 	})
 
+	var unsafeIterValues []string
+	UnsafeIterateDNS(buf, key, func(i, total int, entry []byte) bool {
+		unsafeIterValues = append(unsafeIterValues, string(entry))
+		return true
+	})
+
 	var truncatedValues []string
 	IterateDNS(buf, key, func(i, total int, entry string) bool {
 		if i == total-1 {
@@ -225,10 +231,14 @@ func assertDNSEqual(t *testing.T, expected []string, buf []byte, key string) {
 		assert.Empty(t, truncatedValues)
 	case 1:
 		assert.Equal(t, name, iterValues[0])
+		assert.Equal(t, name, unsafeIterValues[0])
 		assert.Empty(t, truncatedValues)
 	default:
 		assert.Equal(t, name, iterValues[0])
 		assert.Equal(t, names, iterValues[1:])
+
+		assert.Equal(t, name, unsafeIterValues[0])
+		assert.Equal(t, names, unsafeIterValues[1:])
 
 		assert.Equal(t, iterValues[0:len(iterValues)-1], truncatedValues)
 	}

--- a/process/dns_v1.go
+++ b/process/dns_v1.go
@@ -252,7 +252,14 @@ func getDNSNamesV1(buf []byte) []string {
 	}
 	return names
 }
+
 func iterateDNSV1(buf []byte, ip string, cb func(i, total int, entry string) bool) {
+	unsafeIterateDNSV1(buf, ip, func(i, total int, entry []byte) bool {
+		return cb(i, total, string(entry))
+	})
+}
+
+func unsafeIterateDNSV1(buf []byte, ip string, cb func(i, total int, entry []byte) bool) {
 	// Read overview:
 	//	Compute the target bucket for the given ip
 	//	Iterate over all the buckets to find position of the given bucket
@@ -343,8 +350,7 @@ func iterateDNSV1(buf []byte, ip string, cb func(i, total int, entry string) boo
 
 			start := int(namePosition) + bytesReadForName
 
-			name := string(nameBuffer[start : start+int(nameLength)])
-			if !cb(j, int(nameCount), name) {
+			if !cb(j, int(nameCount), nameBuffer[start:start+int(nameLength)]) {
 				return
 			}
 		}


### PR DESCRIPTION
This will allow iterating DNS entries without allocating strings for them