### PR TITLE
switch zstd path to github.com/DataDog/zstd_0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,7 +11,7 @@
 
 [[projects]]
   digest = "1:f3662169bf21f0406cdad064a592c5a052e8ba32f64a360d755544cd5a98dba8"
-  name = "github.com/DataDog/zstd"
+  name = "github.com/DataDog/zstd_0"
   packages = ["."]
   pruneopts = ""
   revision = "2b373cbe6ac0c8e6960bbd18026ceb269eef89f5"
@@ -64,7 +64,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/DataDog/mmh3",
-    "github.com/DataDog/zstd",
+    "github.com/DataDog/zstd_0",
     "github.com/gogo/protobuf/gogoproto",
     "github.com/gogo/protobuf/jsonpb",
     "github.com/gogo/protobuf/proto",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -3,7 +3,7 @@
   version = "=v1.0.0"
 
 [[constraint]]
-  name = "github.com/DataDog/zstd"
+  name = "github.com/DataDog/zstd_0"
   revision = "2b373cbe6ac0c8e6960bbd18026ceb269eef89f5"
 
 [[constraint]]

--- a/process/message.go
+++ b/process/message.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/DataDog/zstd_0"
+	zstd_0 "github.com/DataDog/zstd_0"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 )

--- a/process/message.go
+++ b/process/message.go
@@ -11,7 +11,7 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/DataDog/zstd"
+	"github.com/DataDog/zstd_0"
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
 )
@@ -58,7 +58,7 @@ func unmarshal(enc MessageEncoding, body []byte, m proto.Message) error {
 	case MessageEncodingJSON:
 		return jsonpb.Unmarshal(bytes.NewReader(body), m)
 	case MessageEncodingZstdPB:
-		d, err := zstd.Decompress(nil, body)
+		d, err := zstd_0.Decompress(nil, body)
 		if err != nil {
 			return err
 		}
@@ -248,7 +248,7 @@ func EncodeMessage(m Message) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		p, err = zstd.Compress(nil, pb)
+		p, err = zstd_0.Compress(nil, pb)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
zstd `v0.5.x` is not compatible with current `v1.x` version. 
In ought to migrate other repositories that depend on to `v1.x` we need to update package name and import path to avoid symbol collision.