### PR TITLE
update zstd rev to get version with mangled symbols

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,11 +10,11 @@
   version = "1.0.0"
 
 [[projects]]
-  digest = "1:f3662169bf21f0406cdad064a592c5a052e8ba32f64a360d755544cd5a98dba8"
+  digest = "1:9bd83b487e688ad3403375726c51548876c35fc1c217fc6f653bcf5670134f27"
   name = "github.com/DataDog/zstd_0"
   packages = ["."]
   pruneopts = ""
-  revision = "2b373cbe6ac0c8e6960bbd18026ceb269eef89f5"
+  revision = "586c1286621ffa183e6b66eb1df0aa52596b5ca2"
 
 [[projects]]
   digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,7 @@
 
 [[constraint]]
   name = "github.com/DataDog/zstd_0"
-  revision = "2b373cbe6ac0c8e6960bbd18026ceb269eef89f5"
+  revision = "586c1286621ffa183e6b66eb1df0aa52596b5ca2"
 
 [[constraint]]
   name = "github.com/DataDog/mmh3"


### PR DESCRIPTION
New version mangles zstd C symbols so it can coexist with the latest zstd lib (v1.x).

Current dd-go revision is [0013387](https://github.com/DataDog/dd-go/blob/prod/Gopkg.toml#L127)

Rev diff:
```
*~>git lol 2bf71ec48360..
*   586c128 (HEAD -> 0.5.x, origin/HEAD, origin/0.5.x) Merge pull request #1 from DataDog/dm/0.5.x-mangle
|\
| * 6e30082 mangle sssort
| * 4b44c08 rename Go package name to zstd_0
| * 1648ca8 mangle all symbols to be able to co-exist with 1.x
|/
*   0013387 Merge pull request #50 from DataDog/elijah/fix-empty-0.5
|\
| * 269e708 add comment explaining hack in previous step
| * fc9564d give cgo more help figuring out what's in srcPtr
| * 4c4c7eb backport #42 to 0.5.x (Correctly handle compressing empty slice)
|/
* 2b373cb Merge pull request #40 from DataDog/dm/decompress-state-on-stack
* ab60b0f decompress: allocate decompression context on stack
* ```


Rake tests ✅ 
```
*~>rake test
go list ./... | grep -v vendor | xargs go test -v
?   	github.com/DataDog/agent-payload/gogen	[no test files]
?   	github.com/DataDog/agent-payload/pb	[no test files]
=== RUN   TestV1EncodeDNS
--- PASS: TestV1EncodeDNS (0.00s)
=== RUN   TestV1EncodeDNS_Empty
--- PASS: TestV1EncodeDNS_Empty (0.00s)
=== RUN   TestV1EncodeDNS_NoNames
--- PASS: TestV1EncodeDNS_NoNames (0.00s)
=== RUN   TestV1EncodeDNS_SampleData
=== RUN   TestV1EncodeDNS_SampleData/samples.txt
=== RUN   TestV1EncodeDNS_SampleData/big_ips.txt
=== RUN   TestV1EncodeDNS_SampleData/big_entries.txt
--- PASS: TestV1EncodeDNS_SampleData (0.01s)
    --- PASS: TestV1EncodeDNS_SampleData/samples.txt (0.01s)
    --- PASS: TestV1EncodeDNS_SampleData/big_ips.txt (0.00s)
    --- PASS: TestV1EncodeDNS_SampleData/big_entries.txt (0.00s)
=== RUN   TestDecodeZstd05Payload
--- PASS: TestDecodeZstd05Payload (0.00s)
=== RUN   TestMessageTypeString
--- PASS: TestMessageTypeString (0.00s)
=== RUN   TestV1TagEncoder
=== RUN   TestV1TagEncoder/TestGetTagsEmpty
=== RUN   TestV1TagEncoder/TestOverflowNumberOfTags
=== RUN   TestV1TagEncoder/TestOverflowTagLength
=== RUN   TestV1TagEncoder/TestTagSerde
=== RUN   TestV1TagEncoder/TestTagSerdeRealTags
=== RUN   TestV1TagEncoder/TestUnicodeTags
--- PASS: TestV1TagEncoder (0.26s)
    --- PASS: TestV1TagEncoder/TestGetTagsEmpty (0.00s)
    --- PASS: TestV1TagEncoder/TestOverflowNumberOfTags (0.01s)
    --- PASS: TestV1TagEncoder/TestOverflowTagLength (0.25s)
    --- PASS: TestV1TagEncoder/TestTagSerde (0.00s)
    --- PASS: TestV1TagEncoder/TestTagSerdeRealTags (0.00s)
    --- PASS: TestV1TagEncoder/TestUnicodeTags (0.00s)
=== RUN   TestV1DecodedTags
--- PASS: TestV1DecodedTags (0.00s)
=== RUN   TestV2TagEncoder
=== RUN   TestV2TagEncoder/TestGetTagsEmpty
=== RUN   TestV2TagEncoder/TestOverflowNumberOfTags
=== RUN   TestV2TagEncoder/TestOverflowTagLength
=== RUN   TestV2TagEncoder/TestTagSerde
=== RUN   TestV2TagEncoder/TestTagSerdeRealTags
=== RUN   TestV2TagEncoder/TestUnicodeTags
--- PASS: TestV2TagEncoder (0.36s)
    --- PASS: TestV2TagEncoder/TestGetTagsEmpty (0.00s)
    --- PASS: TestV2TagEncoder/TestOverflowNumberOfTags (0.03s)
    --- PASS: TestV2TagEncoder/TestOverflowTagLength (0.30s)
    --- PASS: TestV2TagEncoder/TestTagSerde (0.00s)
    --- PASS: TestV2TagEncoder/TestTagSerdeRealTags (0.03s)
    --- PASS: TestV2TagEncoder/TestUnicodeTags (0.00s)
PASS
ok  	github.com/DataDog/agent-payload/process	(cached)
?   	github.com/DataDog/agent-payload/proto/logs	[no test files]
?   	github.com/DataDog/agent-payload/proto/metrics	[no test files]
?   	github.com/DataDog/agent-payload/proto/process	[no test files]
```