### PR TITLE
[dns] Add error handling to DNS iteration

### DIFF
--- a/process/connections.go
+++ b/process/connections.go
@@ -29,8 +29,8 @@ func (m *CollectorConnections) GetDNS(addr *Addr) (string, []string) {
 }
 
 // IterateDNS iterates over all of the DNS entries for the given addr, invoking the provided callback for each one
-func (m *CollectorConnections) IterateDNS(addr *Addr, cb func(i, total int, entry string) bool) {
-	IterateDNS(m.EncodedDNS, addr.Ip, cb)
+func (m *CollectorConnections) IterateDNS(addr *Addr, cb func(i, total int, entry string) bool) error {
+	return IterateDNS(m.EncodedDNS, addr.Ip, cb)
 }
 
 // GetDNSNames returns all the DNS entries

--- a/process/dns.go
+++ b/process/dns.go
@@ -33,26 +33,29 @@ func getDNSNames(buf []byte) []string {
 }
 
 // IterateDNS invokes the callback function for each DNS entry for the given IP in the given buffer
-func IterateDNS(buf []byte, ip string, cb func(i, total int, entry string) bool) {
+func IterateDNS(buf []byte, ip string, cb func(i, total int, entry string) bool) error {
 	if len(buf) == 0 || ip == "" {
-		return
+		return nil
 	}
 
 	switch buf[0] {
 	case dnsVersion1:
-		iterateDNSV1(buf, ip, cb)
+		return iterateDNSV1(buf, ip, cb)
 	}
+	return nil
 }
 
 // UnsafeIterateDNS invokes the callback function for each DNS entry for the given IP in the given buffer.
 // Each entry is a the slice from the overall buffer.  It should be copied before use
-func UnsafeIterateDNS(buf []byte, ip string, cb func(i, total int, entry []byte) bool) {
+func UnsafeIterateDNS(buf []byte, ip string, cb func(i, total int, entry []byte) bool) error {
 	if len(buf) == 0 || ip == "" {
-		return
+		return nil
 	}
 
 	switch buf[0] {
 	case dnsVersion1:
-		unsafeIterateDNSV1(buf, ip, cb)
+		return unsafeIterateDNSV1(buf, ip, cb)
 	}
+
+	return nil
 }


### PR DESCRIPTION
We encountered some corrupted DNS payloads that caused the service reading these to panic.  This commit adds some error handling to the iteration process to ensure that corrupted payloads do not panic

@DataDog/networks 