### PR TITLE
Upgrade github.com/DataDog/mmh3 to 1.2.0

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  digest = "1:eb704e209bd926f5f44c97c0646cd20906c1cd714ba7a5ad4dc70f37ca98c7c0"
+  digest = "1:c4b3e2b49c4f3a6714b55523fcbf762d5c88967b8efa69fff1ea47f424f3c75a"
   name = "github.com/DataDog/mmh3"
   packages = ["."]
   pruneopts = ""
-  revision = "6574a4241c5250712174e75a1042b4595124889e"
-  version = "1.0.0"
+  revision = "30884ca2197a84c5a6d858be1a4853abc6b89002"
+  version = "1.2.0"
 
 [[projects]]
   digest = "1:9bd83b487e688ad3403375726c51548876c35fc1c217fc6f653bcf5670134f27"


### PR DESCRIPTION
This has basically no performance impact, but gets us to a
properly-licensed version.

```
name                         old time/op    new time/op    delta
DNSDecode/samples.txt-8         184µs ± 5%     184µs ± 5%    ~     (p=0.795 n=19+19)
DNSDecode/big_ips.txt-8        33.1µs ±10%    32.6µs ± 7%    ~     (p=0.421 n=21+19)
DNSDecode/big_entries.txt-8    31.9µs ± 9%    32.4µs ± 3%    ~     (p=0.057 n=21+18)
DNSEncode/samples.txt-8         348µs ± 7%     352µs ± 7%    ~     (p=0.142 n=21+20)
DNSEncode/big_ips.txt-8        27.5µs ± 1%    28.3µs ± 4%  +2.65%  (p=0.000 n=16+18)
DNSEncode/big_entries.txt-8    29.1µs ± 4%    28.4µs ± 1%  -2.57%  (p=0.000 n=11+20)

name                         old alloc/op   new alloc/op   delta
DNSDecode/samples.txt-8        45.0kB ± 0%    45.0kB ± 0%    ~     (all equal)
DNSDecode/big_ips.txt-8        6.24kB ± 0%    6.24kB ± 0%    ~     (all equal)
DNSDecode/big_entries.txt-8    6.79kB ± 0%    6.79kB ± 0%    ~     (all equal)
DNSEncode/samples.txt-8         128kB ± 0%     128kB ± 0%    ~     (p=0.174 n=21+20)
DNSEncode/big_ips.txt-8        9.30kB ± 0%    9.30kB ± 0%    ~     (all equal)
DNSEncode/big_entries.txt-8    7.74kB ± 0%    7.74kB ± 0%    ~     (all equal)

name                         old allocs/op  new allocs/op  delta
DNSDecode/samples.txt-8         1.16k ± 0%     1.16k ± 0%    ~     (all equal)
DNSDecode/big_ips.txt-8           142 ± 0%       142 ± 0%    ~     (all equal)
DNSDecode/big_entries.txt-8       160 ± 0%       160 ± 0%    ~     (all equal)
DNSEncode/samples.txt-8         1.15k ± 0%     1.15k ± 0%    ~     (all equal)
DNSEncode/big_ips.txt-8           112 ± 0%       112 ± 0%    ~     (all equal)
DNSEncode/big_entries.txt-8       102 ± 0%       102 ± 0%    ~     (all equal)

name                         old bytes      new bytes      delta
DNSEncode/samples.txt-8        48.1kB ± 0%    48.1kB ± 0%    ~     (p=0.257 n=21+20)
DNSEncode/big_ips.txt-8        2.43kB ± 0%    2.43kB ± 0%    ~     (p=0.418 n=20+20)
DNSEncode/big_entries.txt-8    2.26kB ± 0%    2.26kB ± 0%    ~     (p=1.000 n=10+20)
```
Given that nothing about Hash32 changed at all, I'm a bit surprised to see _any_ significant differences here, but even those are small (and maybe to do with branch offsets or instruction alignment?).

I experimented with switching to github.com/twmb/murmur3, but it proved substantially slower, due I think to allocating a lot more than mmh3 does.