### PR TITLE
Improve error handling on DNS v2 read path

### DIFF
--- a/process/dns_v2.go
+++ b/process/dns_v2.go
@@ -287,11 +287,15 @@ func getDNSNameListV2(buf []byte) []string {
 }
 
 func getDNSNameAsByteSliceByOffset(buf []byte, offset int) (stringasbyteslice []byte, err error) {
-	if offset > len(buf) {
-		return nil, fmt.Errorf("offset out of range %d > %d", offset, len(buf))
+	if offset >= len(buf) {
+		return nil, fmt.Errorf("offset out of range %d >= %d", offset, len(buf))
 	}
 	namelen, bytesReadForNameLen := binary.Uvarint(buf[offset:])
 	offset += bytesReadForNameLen
+	if offset+int(namelen) > len(buf) {
+		return nil, fmt.Errorf("offset out of range [%d:%d] > %d", offset, offset+int(namelen), len(buf))
+	}
+
 	return buf[offset : offset+int(namelen)], nil
 }
 


### PR DESCRIPTION
We are seeing some payloads panic due to reading past the end of the domain database.

This commit also surfaces errors that occur during iteration

@DataDog/networks 