### PR TITLE
Fixes intermittent encoding problem.

### DIFF
--- a/process/dns_v2.go
+++ b/process/dns_v2.go
@@ -206,26 +206,25 @@ func (e *V2DNSEncoder) EncodeDomainDatabase(names []string) ([]byte, []int32, er
 
 	for _, val := range names {
 		/* we're going to hard-code the `offsetofmiddle` to zero, and not use it.
-			       Keep the field, so we don't have to rev the layout of the buffer.
-				   but don't use it as there's a very awful bug here.
+		       Keep the field, so we don't have to rev the layout of the buffer.
+			   but don't use it as there's a very awful bug here.
 
-				   Previous code:
+			   Previous code:
+		if idx == indexOfMiddle {
 
-				if idx == indexOfMiddle {
+			offsetOfMiddle = bufferSize
+			bufferSize += e.varIntSize(offsetOfMiddle)
+			offsetOfMiddle = bufferSize
+		}
+			In the above, if offsetOfMiddle happens to be 127 (or any other subsequent size
+			that causes the size of a varint to go up), we have an off-by-one bug.  The offset
+			is 127, so we compute the size (which is 1), and then increment the buffer size to
+			match. However, since the offsetOfMiddle is now 128, the size of the varint is now
+			2, and the whole buffer's whacked.  Only when the middle happens to be on the boundary
+			of when the varint size changes.
 
-		  			offsetOfMiddle = bufferSize
-					bufferSize += e.varIntSize(offsetOfMiddle)
-					offsetOfMiddle = bufferSize
-				}
-					In the above, if offsetOfMiddle happens to be 127 (or any other subsequent size
-					that causes the size of a varint to go up), we have an off-by-one bug.  The offset
-					is 127, so we compute the size (which is 1), and then increment the buffer size to
-					match. However, since the offsetOfMiddle is now 128, the size of the varint is now
-					2, and the whole buffer's whacked.  Only when the middle happens to be on the boundary
-					of when the varint size changes.
-
-					In this buffer, we weren't actually using the indexOfMiddle, it was left for
-					future optimization.  Now, _never_ use it.
+			In this buffer, we weren't actually using the indexOfMiddle, it was left for
+			future optimization.  Now, _never_ use it.
 		*/
 
 		bufferSize += e.varIntSize(len(val))

--- a/process/dns_v2_test.go
+++ b/process/dns_v2_test.go
@@ -2,7 +2,6 @@ package process
 
 import (
 	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"path"
@@ -13,37 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestBadDNSStaging(t *testing.T) {
-	lookup, err := hex.DecodeString("0203000301003445030d31302e3133342e33362e3231300203430b31302e3133342e342e3436020381010d31302e3133342e34322e3132370203c101010c31302e3133342e33302e393502030300")
-	require.NoError(t, err)
-
-	database, err := hex.DecodeString("0480013f657463642d322e657463642e6f64646973682d612d6b38732d657463642d64656661756c742e7376632e706172656e74312e636c75737465722e6c6f63616c3d657463642d342e657463642e7374726970652d6b38732d657463642d64656661756c742e7376632e706172656e74312e636c75737465722e6c6f63616c3f657463642d332e657463642e6f64646973682d612d6b38732d657463642d64656661756c742e7376632e706172656e74312e636c75737465722e6c6f63616c3f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
-	require.NoError(t, err)
-
-	strings := getDNSNameListV2(database)
-	fmt.Printf("%v\n", strings)
-	addr := &Addr{
-		Ip: "10.134.42.127",
-	}
-
-	encodedDNSLookups := make([]byte, len(lookup))
-	copy(encodedDNSLookups, lookup)
-
-	encodedDomainDatabase := make([]byte, len(database))
-	copy(encodedDomainDatabase, database)
-
-	cc := &CollectorConnections{
-		EncodedDnsLookups:     encodedDNSLookups,
-		EncodedDomainDatabase: encodedDomainDatabase,
-	}
-
-	err = cc.IterateDNS(addr, func(i, total int, entry string) bool {
-		fmt.Printf("%d/%d -- %s\n", i, total, entry)
-		return true
-	})
-	require.NoError(t, err)
-}
 
 func getDNSNameFromListByIndex(buf []byte, index int) (string, error) {
 	num, bytesRead := binary.Uvarint(buf[0:])
@@ -109,10 +77,11 @@ func TestV2DomainDatabaseEncoding(t *testing.T) {
 		"bar.com",
 	}
 	knownBoundaryProblemDB := []string{
-		"etcd-2.etcd.oddish-a-k8s-etcd-default.svc.parent1.cluster.local",
-		"etcd-4.etcd.stripe-k8s-etcd-default.svc.parent1.cluster.local",
-		"etcd-3.etcd.oddish-a-k8s-etcd-default.svc.parent1.cluster.local",
-		"etcd-1.etcd.oddish-a-k8s-etcd-default.svc.parent1.cluster.local",
+		"avery-specific-host-1-with.sixtythreechar.hostname.testname.com",
+		"avery-specific-host-1-with.sixtyonechar.hostname.testname.com",
+
+		"avery-specific-host-2-with.sixtythreechar.hostname.testname.com",
+		"avery-specific-host-3-with.sixtythreechar.hostname.testname.com",
 	}
 	doTestForDNSDB(t, dnsdb)
 	doTestForDNSDB(t, knownBoundaryProblemDB)

--- a/process/dns_v2_test.go
+++ b/process/dns_v2_test.go
@@ -2,6 +2,7 @@ package process
 
 import (
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"path"
@@ -13,6 +14,37 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBadDNSStaging(t *testing.T) {
+	lookup, err := hex.DecodeString("0203000301003445030d31302e3133342e33362e3231300203430b31302e3133342e342e3436020381010d31302e3133342e34322e3132370203c101010c31302e3133342e33302e393502030300")
+	require.NoError(t, err)
+
+	database, err := hex.DecodeString("0480013f657463642d322e657463642e6f64646973682d612d6b38732d657463642d64656661756c742e7376632e706172656e74312e636c75737465722e6c6f63616c3d657463642d342e657463642e7374726970652d6b38732d657463642d64656661756c742e7376632e706172656e74312e636c75737465722e6c6f63616c3f657463642d332e657463642e6f64646973682d612d6b38732d657463642d64656661756c742e7376632e706172656e74312e636c75737465722e6c6f63616c3f0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000")
+	require.NoError(t, err)
+
+	strings := getDNSNameListV2(database)
+	fmt.Printf("%v\n", strings)
+	addr := &Addr{
+		Ip: "10.134.42.127",
+	}
+
+	encodedDNSLookups := make([]byte, len(lookup))
+	copy(encodedDNSLookups, lookup)
+
+	encodedDomainDatabase := make([]byte, len(database))
+	copy(encodedDomainDatabase, database)
+
+	cc := &CollectorConnections{
+		EncodedDnsLookups:     encodedDNSLookups,
+		EncodedDomainDatabase: encodedDomainDatabase,
+	}
+
+	err = cc.IterateDNS(addr, func(i, total int, entry string) bool {
+		fmt.Printf("%d/%d -- %s\n", i, total, entry)
+		return true
+	})
+	require.NoError(t, err)
+}
+
 func getDNSNameFromListByIndex(buf []byte, index int) (string, error) {
 	num, bytesRead := binary.Uvarint(buf[0:])
 	offsetOfMiddle, bytesReadForMiddleOffset := binary.Uvarint(buf[bytesRead:])
@@ -22,11 +54,11 @@ func getDNSNameFromListByIndex(buf []byte, index int) (string, error) {
 	if index > int(num-1) {
 		return "", fmt.Errorf("Index out of range %d > %d", index, num)
 	}
-	indexOfMiddle := int(num / 2)
 	currIndex := 0
-	if index > indexOfMiddle {
-		bytesRead = int(offsetOfMiddle)
-		currIndex = int(indexOfMiddle)
+
+	// test and make sure we're not encoding the middle any more
+	if offsetOfMiddle != 0 {
+		return "", fmt.Errorf("Incorrectly encoded buffer")
 	}
 	for currIndex < int(num) {
 		namelen, bytesReadForNameLen := binary.Uvarint(buf[bytesRead:])
@@ -42,14 +74,7 @@ func getDNSNameFromListByIndex(buf []byte, index int) (string, error) {
 	return "", fmt.Errorf("Index not found? %d %d", index, num)
 }
 
-func TestV2DomainDatabaseEncoding(t *testing.T) {
-	dnsdb := []string{
-		"foo.com",
-		"service.example.com",
-		"service2.example.com",
-		"app.example.com",
-		"bar.com",
-	}
+func doTestForDNSDB(t *testing.T, dnsdb []string) {
 	encoder := NewV2DNSEncoder()
 	buf, offsets, err := encoder.EncodeDomainDatabase(dnsdb)
 	assert.Nil(t, err)
@@ -74,8 +99,25 @@ func TestV2DomainDatabaseEncoding(t *testing.T) {
 	// test off of the end
 	_, err = getDNSNameFromListByOffset(buf, len(buf)+2)
 	assert.Error(t, err)
-
 }
+func TestV2DomainDatabaseEncoding(t *testing.T) {
+	dnsdb := []string{
+		"foo.com",
+		"service.example.com",
+		"service2.example.com",
+		"app.example.com",
+		"bar.com",
+	}
+	knownBoundaryProblemDB := []string{
+		"etcd-2.etcd.oddish-a-k8s-etcd-default.svc.parent1.cluster.local",
+		"etcd-4.etcd.stripe-k8s-etcd-default.svc.parent1.cluster.local",
+		"etcd-3.etcd.oddish-a-k8s-etcd-default.svc.parent1.cluster.local",
+		"etcd-1.etcd.oddish-a-k8s-etcd-default.svc.parent1.cluster.local",
+	}
+	doTestForDNSDB(t, dnsdb)
+	doTestForDNSDB(t, knownBoundaryProblemDB)
+}
+
 func indexOf(val string, db []string) int32 {
 	for p, v := range db {
 		if v == val {


### PR DESCRIPTION
The offset of the middle entry of the dns database is being encoded,
but not used (was originally left for future optimization).
However, it has a problem of the result changing its own position.
This works, except in a very specific boundary case.

if offsetOfMiddle happens to be 127 (or any other subsequent size
that causes the size of a varint to go up), we have an off-by-one bug.
The offset is 127, so we compute the size (which is 1), and then increment
the buffer size to match. However, since the offsetOfMiddle is now 128, the
size of the varint is now 2, and the whole buffer's whacked.  Only when the
middle happens to be on the boundary of when the varint size changes.