### PR TITLE
set GOPATH to run 'rake codegen'

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@ The following implementations are available:
 
 After updating the IDL you must:
 
-- Regenerate the code: `rake codegen`
+- Regenerate the code: `GOPATH=$(go env GOPATH) rake codegen`
 - Create a new tag with the updated version of the payload


### PR DESCRIPTION
I had to do this locally.  The Rakefile uses $GOPATH internally, but it's not set in my environment since the go binary can figure out the correct value itself.

Alternative suggestions welcome :)