### PR TITLE
Add UnsafeIterateDNS

### DIFF
--- a/process/connections.go
+++ b/process/connections.go
@@ -62,7 +62,7 @@ func (m *CollectorConnections) GetDNS(addr *Addr) (string, []string, error) {
 	return "", nil, fmt.Errorf("No DNS encoded information")
 }
 
-// IterateDNS iterates over all of the DNS entries for the given addr, invoking the provided callback for each one
+// IterateDNS iterates over all the DNS entries for the given addr, invoking the provided callback for each one
 func (m *CollectorConnections) IterateDNS(addr *Addr, cb func(i, total int, entry string) bool) error {
 	if m.EncodedDNS != nil {
 		return IterateDNS(m.EncodedDNS, addr.Ip, cb)
@@ -73,6 +73,32 @@ func (m *CollectorConnections) IterateDNS(addr *Addr, cb func(i, total int, entr
 			s, err := getDNSNameFromListByOffset(m.EncodedDomainDatabase, int(offset))
 			if err == nil {
 				return cb(i, total, s)
+			}
+			iterError = err
+			return false
+		})
+		if err != nil {
+			return err
+		}
+		if iterError != nil {
+			return iterError
+		}
+	}
+	return nil
+}
+
+// UnsafeIterateDNS iterates over all the DNS entries for the given addr, invoking the provided callback for each one
+// The entry returned is only valid for the lifetime of the fields in this message
+func (m *CollectorConnections) UnsafeIterateDNS(addr *Addr, cb func(i, total int, entry []byte) bool) error {
+	if m.EncodedDNS != nil {
+		return UnsafeIterateDNS(m.EncodedDNS, addr.Ip, cb)
+	}
+	if m.EncodedDnsLookups != nil && m.EncodedDomainDatabase != nil {
+		var iterError error
+		err := UnsafeIterateDNSV2(m.EncodedDnsLookups, addr.Ip, func(i, total int, offset int32) bool {
+			b, err := getDNSNameAsByteSliceByOffset(m.EncodedDomainDatabase, int(offset))
+			if err == nil {
+				return cb(i, total, b)
 			}
 			iterError = err
 			return false

--- a/process/connections_test.go
+++ b/process/connections_test.go
@@ -1,0 +1,70 @@
+package process
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIterateDNS(t *testing.T) {
+	t.Run("v1", func(t *testing.T) {
+		addr := &Addr{Ip: "1.1.1.1"}
+		encoder := NewV1DNSEncoder()
+		buf, err := encoder.Encode(map[string]*DNSEntry{
+			addr.Ip: {Names: []string{"foo", "bar"}},
+		})
+		require.NoError(t, err)
+
+		cc := &CollectorConnections{
+			EncodedDNS: buf,
+		}
+
+		var entries []string
+		err = cc.IterateDNS(addr, func(i, total int, entry string) bool {
+			entries = append(entries, entry)
+			return true
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"foo", "bar"}, entries)
+
+		entries = nil
+		err = cc.UnsafeIterateDNS(addr, func(i, total int, entry []byte) bool {
+			entries = append(entries, string(entry))
+			return true
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"foo", "bar"}, entries)
+	})
+
+	t.Run("v2", func(t *testing.T) {
+		addr := &Addr{Ip: "1.1.1.1"}
+		db := []string{"foo", "bar"}
+		encoder := NewV2DNSEncoder()
+		dbBuf, indexToOffset, err := encoder.EncodeDomainDatabase(db)
+		require.NoError(t, err)
+
+		lookupBuf, err := encoder.EncodeMapped(map[string]*DNSDatabaseEntry{
+			addr.Ip: {NameOffsets: []int32{indexOf("foo", db), indexOf("bar", db)}},
+		}, indexToOffset)
+		require.NoError(t, err)
+
+		cc := CollectorConnections{EncodedDnsLookups: lookupBuf, EncodedDomainDatabase: dbBuf}
+
+		var entries []string
+		err = cc.IterateDNS(addr, func(i, total int, entry string) bool {
+			entries = append(entries, entry)
+			return true
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"foo", "bar"}, entries)
+
+		entries = nil
+		err = cc.UnsafeIterateDNS(addr, func(i, total int, entry []byte) bool {
+			entries = append(entries, string(entry))
+			return true
+		})
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"foo", "bar"}, entries)
+	})
+}


### PR DESCRIPTION
This will allow us to "unsafely" iterate DNS entries without allocating

@DataDog/networks 