### PR TITLE
Checks that buffers have enough bytes to parse and iterate

### DIFF
--- a/process/dns_test.go
+++ b/process/dns_test.go
@@ -1,7 +1,7 @@
 package process
 
 import (
-	fmt "fmt"
+	"fmt"
 	"io/ioutil"
 	"path"
 	"runtime"
@@ -12,6 +12,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 )
+
+const dnsBufLenStr = "dns buffer is too short"
 
 func TestV1EncodeDNS(t *testing.T) {
 	dns := make(map[string]*DNSEntry)
@@ -100,7 +102,7 @@ func TestUnsafeIterationV1_BufLen(t *testing.T) {
 	err := unsafeIterateDNSV1(buf, "ip", func(i, total int, entry []byte) bool {
 		return true
 	})
-	assert.Equal(t, fmt.Errorf("dns buffer is too short"), err)
+	assert.Equal(t, fmt.Errorf(dnsBufLenStr), err)
 }
 
 func BenchmarkDNSDecode(b *testing.B) {

--- a/process/dns_test.go
+++ b/process/dns_test.go
@@ -1,6 +1,7 @@
 package process
 
 import (
+	fmt "fmt"
 	"io/ioutil"
 	"path"
 	"runtime"
@@ -92,6 +93,14 @@ func TestV1EncodeDNS_SampleData(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUnsafeIterationV1_BufLen(t *testing.T) {
+	buf := make([]byte, 2)
+	err := unsafeIterateDNSV1(buf, "ip", func(i, total int, entry []byte) bool {
+		return true
+	})
+	assert.Equal(t, fmt.Errorf("dns buffer is too short"), err)
 }
 
 func BenchmarkDNSDecode(b *testing.B) {

--- a/process/dns_test.go
+++ b/process/dns_test.go
@@ -13,8 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const dnsBufLenStr = "dns buffer is too short"
-
 func TestV1EncodeDNS(t *testing.T) {
 	dns := make(map[string]*DNSEntry)
 
@@ -102,7 +100,7 @@ func TestUnsafeIterationV1_BufLen(t *testing.T) {
 	err := unsafeIterateDNSV1(buf, "ip", func(i, total int, entry []byte) bool {
 		return true
 	})
-	assert.Equal(t, fmt.Errorf(dnsBufLenStr), err)
+	assert.Equal(t, fmt.Errorf(bufTooShortStr), err)
 }
 
 func BenchmarkDNSDecode(b *testing.B) {

--- a/process/dns_v1.go
+++ b/process/dns_v1.go
@@ -9,6 +9,8 @@ import (
 	"github.com/DataDog/mmh3"
 )
 
+const bufTooShortStr = "dns buffer is too short"
+
 // DNS data is encoded as a very basic bucketed hash table.  There are three blocks, or buffers, of data:
 //
 //	The "name" block is all of the unique DNS names.  The length of the name is stored as a varint
@@ -47,6 +49,7 @@ import (
 //	pre-sizing the output buffers
 //
 // This type is not thread safe
+
 type V1DNSEncoder struct {
 	BucketFactor float64
 	scratch      [binary.MaxVarintLen64]byte // Used for varint encoding
@@ -273,7 +276,7 @@ func unsafeIterateDNSV1(buf []byte, ip string, cb func(i, total int, entry []byt
 
 	// Needs 3 bytes so that buf[1:] can convert to uint16
 	if bufLen <= 2 {
-		return fmt.Errorf("dns buffer is too short")
+		return fmt.Errorf(bufTooShortStr)
 	}
 	// Read overview:
 	//	Compute the target bucket for the given ip

--- a/process/dns_v1.go
+++ b/process/dns_v1.go
@@ -271,6 +271,7 @@ func iterateDNSV1(buf []byte, ip string, cb func(i, total int, entry string) boo
 func unsafeIterateDNSV1(buf []byte, ip string, cb func(i, total int, entry []byte) bool) error {
 	bufLen := len(buf)
 
+	// Needs 3 bytes so that buf[1:] can convert to uint16
 	if bufLen <= 2 {
 		return fmt.Errorf("dns buffer is too short")
 	}

--- a/process/dns_v1.go
+++ b/process/dns_v1.go
@@ -26,23 +26,25 @@ import (
 //	of the bucket in the bucket block
 //
 // The overall buffer is encoded as:
+//
 //	1 byte indicating version
-// 	2 bytes indicating the number of buckets
+//	2 bytes indicating the number of buckets
 //	varint indicating the length of the name buffer.
 //	varint indicating the length of the position buffer
-// 	varint indicating the position of the "middle" (bucketCount / 2) bucket in the position block
+//	varint indicating the position of the "middle" (bucketCount / 2) bucket in the position block
 //		We will use this to skip the half of the buckets when searching for the target bucket index
 //	position block
 //	bucket block
 //	name block
 //
 // Notes:
+//
 //	Using varints saves space at the cost of not having random access to certain sections of data, particularly the
 //	bucket position mapping.  This was a deliberate trade off to reduce the size of the payload and thus memory usage
 //
 //	Varints are also more finicky to deal with in terms of calculating required space ahead of time.  This increases
 //	the implementation complexity, or at least the line count, but we reduce allocations & memory usage by
-// 	pre-sizing the output buffers
+//	pre-sizing the output buffers
 //
 // This type is not thread safe
 type V1DNSEncoder struct {
@@ -269,7 +271,7 @@ func iterateDNSV1(buf []byte, ip string, cb func(i, total int, entry string) boo
 func unsafeIterateDNSV1(buf []byte, ip string, cb func(i, total int, entry []byte) bool) error {
 	bufLen := len(buf)
 
-	if bufLen < 2 {
+	if bufLen <= 2 {
 		return fmt.Errorf("dns buffer is too short")
 	}
 	// Read overview:

--- a/process/dns_v2.go
+++ b/process/dns_v2.go
@@ -307,7 +307,7 @@ func getDNSNameListV2(buf []byte) []string {
 }
 
 func getDNSNameAsByteSliceByOffset(buf []byte, offset int) (stringasbyteslice []byte, err error) {
-	if offset >= len(buf)  {
+	if offset >= len(buf) {
 		return nil, fmt.Errorf("offset out of range %d >= %d", offset, len(buf))
 	}
 	if offset < 0 {
@@ -341,7 +341,7 @@ func iterateDNSV2(buf []byte, ip string, cb func(i, total int, entry int32) bool
 func unsafeIterateDNSV2(buf []byte, ip string, cb func(i, total int, entry int32) bool) error {
 	bufLen := len(buf)
 
-	if bufLen < 2 {
+	if bufLen <= 2 {
 		return fmt.Errorf("dns buffer is too short")
 	}
 	// Read overview:

--- a/process/dns_v2.go
+++ b/process/dns_v2.go
@@ -343,7 +343,7 @@ func unsafeIterateDNSV2(buf []byte, ip string, cb func(i, total int, entry int32
 
 	// Needs 3 bytes so that buf[1:] can convert to uint16
 	if bufLen <= 2 {
-		return fmt.Errorf("dns buffer is too short")
+		return fmt.Errorf(bufTooShortStr)
 	}
 	// Read overview:
 	//	Compute the target bucket for the given ip

--- a/process/dns_v2.go
+++ b/process/dns_v2.go
@@ -341,6 +341,7 @@ func iterateDNSV2(buf []byte, ip string, cb func(i, total int, entry int32) bool
 func unsafeIterateDNSV2(buf []byte, ip string, cb func(i, total int, entry int32) bool) error {
 	bufLen := len(buf)
 
+	// Needs 3 bytes so that buf[1:] can convert to uint16
 	if bufLen <= 2 {
 		return fmt.Errorf("dns buffer is too short")
 	}

--- a/process/dns_v2_test.go
+++ b/process/dns_v2_test.go
@@ -149,7 +149,7 @@ func TestUnsafeIteration_BufLen(t *testing.T) {
 	err := unsafeIterateDNSV2(buf, "ip", func(i, total int, entry int32) bool {
 		return true
 	})
-	assert.Equal(t, fmt.Errorf("dns buffer is too short"), err)
+	assert.Equal(t, fmt.Errorf(dnsBufLenStr), err)
 }
 
 func TestV2EncodeDNS_NoNames(t *testing.T) {

--- a/process/dns_v2_test.go
+++ b/process/dns_v2_test.go
@@ -149,7 +149,7 @@ func TestUnsafeIteration_BufLen(t *testing.T) {
 	err := unsafeIterateDNSV2(buf, "ip", func(i, total int, entry int32) bool {
 		return true
 	})
-	assert.Equal(t, fmt.Errorf(dnsBufLenStr), err)
+	assert.Equal(t, fmt.Errorf(bufTooShortStr), err)
 }
 
 func TestV2EncodeDNS_NoNames(t *testing.T) {

--- a/process/dns_v2_test.go
+++ b/process/dns_v2_test.go
@@ -144,6 +144,14 @@ func TestV2EncodeDNS_Empty(t *testing.T) {
 	assert.Equal(t, 0, len(names))
 }
 
+func TestUnsafeIteration_BufLen(t *testing.T) {
+	buf := make([]byte, 2)
+	err := unsafeIterateDNSV2(buf, "ip", func(i, total int, entry int32) bool {
+		return true
+	})
+	assert.Equal(t, fmt.Errorf("dns buffer is too short"), err)
+}
+
 func TestV2EncodeDNS_NoNames(t *testing.T) {
 	dns := make(map[string]*DNSDatabaseEntry)
 

--- a/process/tags.go
+++ b/process/tags.go
@@ -147,15 +147,31 @@ func iterateV1(buffer []byte, tagIndex int, cb func(i, total int, tag string) bo
 }
 
 func unsafeIterateV1(buffer []byte, tagIndex int, cb func(i, total int, tag []byte) bool) {
+
+	if tagIndex < 0 || tagIndex >= len(buffer) {
+		return
+	}
+
 	tagBuffer := buffer[tagIndex:]
 	readIndex := 0
+
+	if len(tagBuffer[readIndex:]) < lenUint16 {
+		return
+	}
 
 	numTags := int(binary.LittleEndian.Uint16(tagBuffer[readIndex:]))
 	readIndex += 2
 
 	for i := 0; i < numTags; i++ {
+		if readIndex >= len(tagBuffer) || len(tagBuffer[readIndex:]) < lenUint16 {
+			continue
+		}
 		tagLength := int(binary.LittleEndian.Uint16(tagBuffer[readIndex:]))
 		readIndex += 2
+
+		if readIndex+tagLength > len(buffer) {
+			continue
+		}
 
 		if !cb(i, numTags, tagBuffer[readIndex:readIndex+tagLength]) {
 			return

--- a/process/tags_test.go
+++ b/process/tags_test.go
@@ -147,6 +147,30 @@ func TestV1DecodedTags(t *testing.T) {
 	}
 }
 
+func TestUnsafeIterationV1(t *testing.T) {
+	// buff = 2
+	buf := make([]byte, 2)
+	assert.NotPanics(t, func() {
+		unsafeIterateV1(buf, 0, func(i, total int, tag []byte) bool { return true })
+	})
+
+	// buff = 1
+	assert.NotPanics(t, func() {
+		unsafeIterateV1(buf[1:], 0, func(i, total int, tag []byte) bool { return true })
+	})
+
+	// indx > buff
+	buf = make([]byte, 6)
+	assert.NotPanics(t, func() {
+		unsafeIterateV1(buf, 10, func(i, total int, tag []byte) bool { return true })
+	})
+
+	// footerBuffer < 2
+	assert.NotPanics(t, func() {
+		unsafeIterateV1(buf, 5, func(i, total int, tag []byte) bool { return true })
+	})
+}
+
 func BenchmarkTagEncode(b *testing.B) {
 	allTags := readTestTags(b, "testdata/tags.txt")
 

--- a/process/tags_v2.go
+++ b/process/tags_v2.go
@@ -29,6 +29,7 @@ type V2TagEncoder struct {
 
 // 1 meta byte + 4 bytes for the index of the footer block
 const v2PreambleLength = 1 + 4
+const LenUint16 = 2 
 
 var footerPool = sync.Pool{
 	New: func() interface{} {
@@ -169,7 +170,11 @@ func unsafeIterateV2(buffer []byte, tagIndex int, cb func(i, total int, tag []by
 
 	footerBuffer := buffer[idx:]
 	footerIndex := 0
-
+	
+	if len(footerBuffer[footerIndex:]) < LenUint16 {
+		return
+	}
+	
 	numTags := int(binary.LittleEndian.Uint16(footerBuffer[footerIndex:]))
 	footerIndex += 2
 

--- a/process/tags_v2.go
+++ b/process/tags_v2.go
@@ -14,12 +14,12 @@ import (
 // and is appended to the end of the buffer
 //
 // The format of the buffer is:
-// - 1 byte for meta (currently used for specifying version)
-// - 4 bytes for position of footer blob in overall buffer
-// - N bytes for all tags, stored sequentially.
-//		Each tag is 2 bytes for the length of the tag and N bytes for the tag itself
-// - N bytes for the footer blob.  Each entry in the footer is 2 bytes for the number of tags and then N 4 byte
-//		integers, each representing the location of the tag in the tag blob
+//   - 1 byte for meta (currently used for specifying version)
+//   - 4 bytes for position of footer blob in overall buffer
+//   - N bytes for all tags, stored sequentially.
+//     Each tag is 2 bytes for the length of the tag and N bytes for the tag itself
+//   - N bytes for the footer blob.  Each entry in the footer is 2 bytes for the number of tags and then N 4 byte
+//     integers, each representing the location of the tag in the tag blob
 type V2TagEncoder struct {
 	tags        map[string]uint32
 	order       []string
@@ -28,8 +28,11 @@ type V2TagEncoder struct {
 }
 
 // 1 meta byte + 4 bytes for the index of the footer block
-const v2PreambleLength = 1 + 4
-const LenUint16 = 2 
+const (
+	v2PreambleLength = 1 + 4
+	lenUint16        = 2
+	lenUint32        = 4
+)
 
 var footerPool = sync.Pool{
 	New: func() interface{} {
@@ -164,27 +167,42 @@ func iterateV2(buffer []byte, tagIndex int, cb func(i, total int, tag string) bo
 }
 
 func unsafeIterateV2(buffer []byte, tagIndex int, cb func(i, total int, tag []byte) bool) {
+	if len(buffer[1:]) < lenUint32 {
+		return
+	}
 	footerPosition := binary.LittleEndian.Uint32(buffer[1:])
 
 	idx := int(footerPosition) + tagIndex
-
-	footerBuffer := buffer[idx:]
-	footerIndex := 0
-	
-	if len(footerBuffer[footerIndex:]) < LenUint16 {
+	if idx >= len(buffer) {
 		return
 	}
-	
+	footerBuffer := buffer[idx:]
+	footerIndex := 0
+
+	if len(footerBuffer[footerIndex:]) < lenUint16 {
+		return
+	}
+
 	numTags := int(binary.LittleEndian.Uint16(footerBuffer[footerIndex:]))
 	footerIndex += 2
 
 	for i := 0; i < numTags; i++ {
+		if footerIndex >= len(footerBuffer) || len(footerBuffer[footerIndex:]) < lenUint32 {
+			continue
+		}
 		tagPosition := int(binary.LittleEndian.Uint32(footerBuffer[footerIndex:]))
 
+		if tagPosition >= len(buffer) || len(buffer[tagPosition:]) < lenUint16 {
+			continue
+		}
 		tagLength := int(binary.LittleEndian.Uint16(buffer[tagPosition:]))
 
 		start := tagPosition + 2
 		end := start + tagLength
+
+		if end > len(buffer) {
+			continue
+		}
 
 		if !cb(i, numTags, buffer[start:end]) {
 			return

--- a/process/tags_v2_test.go
+++ b/process/tags_v2_test.go
@@ -5,11 +5,36 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
 func TestV2TagEncoder(t *testing.T) {
 	suite.Run(t, &TagSerdeTestSuite{encoder: NewV2TagEncoder()})
+}
+
+func TestUnsafeIteration(t *testing.T) {
+	// buff = 2
+	buf := make([]byte, 2)
+	assert.NotPanics(t, func() {
+		unsafeIterateV2(buf, 0, func(i, total int, tag []byte) bool { return true })
+	})
+
+	// buff = 1
+	assert.NotPanics(t, func() {
+		unsafeIterateV2(buf[1:], 0, func(i, total int, tag []byte) bool { return true })
+	})
+
+	// indx > buff
+	buf = make([]byte, 6)
+	assert.NotPanics(t, func() {
+		unsafeIterateV2(buf, 10, func(i, total int, tag []byte) bool { return true })
+	})
+
+	// footerBuffer < 2
+	assert.NotPanics(t, func() {
+		unsafeIterateV2(buf, 5, func(i, total int, tag []byte) bool { return true })
+	})
 }
 
 func BenchmarkTagEncoders(b *testing.B) {

--- a/process/tags_v2_test.go
+++ b/process/tags_v2_test.go
@@ -13,7 +13,7 @@ func TestV2TagEncoder(t *testing.T) {
 	suite.Run(t, &TagSerdeTestSuite{encoder: NewV2TagEncoder()})
 }
 
-func TestUnsafeIteration(t *testing.T) {
+func TestUnsafeIterationV2(t *testing.T) {
 	// buff = 2
 	buf := make([]byte, 2)
 	assert.NotPanics(t, func() {


### PR DESCRIPTION
I added a checks to avoid an out of index range for tags and dns. This came to light after a pentest.