### PR TITLE
Add some fuzzing on dns 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -93,6 +93,11 @@ task :test do
   sh cmd
 end
 
+task :fuzz do
+  cmd = "go list ./... | grep -v vendor | xargs -n 1 go test -v -fuzztime=20s -fuzz '.*' "
+  sh cmd
+end
+
 desc "Run all code generation."
 task :codegen => ['codegen:all']
 

--- a/process/dns.go
+++ b/process/dns.go
@@ -1,9 +1,21 @@
 package process
 
-type DNSEncoder interface {
+type DNSEncoderV1 interface {
 	Encode(dns map[string]*DNSEntry) ([]byte, error)
-	EncodeMapped(dns map[string]*DNSDatabaseEntry, indexToOffset []int32) ([]byte, error)
+}
+
+type DNSEncoderV2 interface {
+	// EncodeDomainDatabase encodes a list of domains into a flattened []byte format
+	// The names parameter is a list of domain names.
+	// The first return value is a []byte containing all the input domains
+	// the second argument maps the indexes in the names slice (e.g. 0, 1, 2, 3) to byte offsets into the returned []byte
 	EncodeDomainDatabase(names []string) ([]byte, []int32, error)
+
+	// EncodeMapped creates a secondary index from IP address to one or more domains.
+	// The dns parameter is a map from IP address to a DNSDatabaseEntry (which is simply a list of indexes into
+	// the DNS database which has been previously encoded by EncodeDomainDatabase)
+	// The resulting []byte can be read with GetDNSV2, IterateDNSV2, etc.
+	EncodeMapped(dns map[string]*DNSDatabaseEntry, indexToOffset []int32) ([]byte, error)
 }
 
 const dnsVersion1 byte = 1

--- a/process/dns_v1.go
+++ b/process/dns_v1.go
@@ -67,7 +67,7 @@ const dns1Version1PreambleLength = 3
 // Currently the bucket count is calculated as `len(input) * bucketFactor`
 const defaultBucketFactor = 0.75
 
-func NewV1DNSEncoder() DNSEncoder {
+func NewV1DNSEncoder() DNSEncoderV1 {
 	return &V1DNSEncoder{
 		BucketFactor: defaultBucketFactor,
 	}


### PR DESCRIPTION
Add fuzz testing on top of DNS serialization. `fuzz` testing is a  technique newly added to Go which will, given a test and inputs to that test, mutate that test and attempt to find non graceful failures. Read more [here](https://go.dev/security/fuzz/)

 
 To run the new fuzz test, either run `rake fuzz` or a particular test with `go test -fuzztime 20s -fuzz FuzzIterateDNSV2 ./process` 

This PR includes several pieces:
* commenting and splitting DNSEncoder into two interfaces: this change is purely to make the dns.go file easier to follow. DNSEncoder has two implementations -- V1DNSEncoder which implements Encode and V2DNSEncoder   which implements domain database. Since the methods implemented by both implementations are totally separate, there's no reason to have a shared interface
* adding a fuzz test in dns_test_v2.go. The fuzz test simply creates an ip->domain mapping, and attempts to read it
    * I also moved some tests around to avoid mixing utilities and tests. See https://github.com/uber-go/guide/blob/master/style.md#function-grouping-and-ordering 
* fixes in dns_v2.go to avoid some panics. Most of these can be addressed by checking the return of Uvarint, which we weren't doing anywhere 
