### PR TITLE
Add a start at review guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,1 @@
+Reviewers: please see the [review guidelines](https://github.com/DataDog/agent-payload/blob/master/REVIEWING.md).

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -4,6 +4,10 @@ This repository is shared between many teams, and it is not always clear what a 
 The following guidelines are intended to help.
 This is a _work in progress_ and additions to this list are welcome.
 
+## Practicalities
+
+If any of the `.proto` files are changed, then the corresponding Go code should be regenerated in the same PR (`GOPATH=$(go env GOPATH) rake codegen`).
+
 ## Implications for the Agent
 
 TBD

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -1,0 +1,17 @@
+# Review Guidelines
+
+This repository is shared between many teams, and it is not always clear what a reviewer should be looking for.
+The following guidelines are intended to help.
+This is a _work in progress_ and additions to this list are welcome.
+
+## Implications for the Agent
+
+TBD
+
+## Implications for Compatibility
+
+When changing proto definitions:
+
+ * Will a sender using the old definition be able to communicate with a receiver using the new definition?
+ * Will a sender using the new definition be able to communicate with a receiver using the old definition?
+ * If a field is removed, is the ID marked as `reserved` so that it will not be accidentally re-used?

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -8,6 +8,8 @@ This is a _work in progress_ and additions to this list are welcome.
 
 If any of the `.proto` files are changed, then the corresponding Go code should be regenerated in the same PR (`GOPATH=$(go env GOPATH) rake codegen`).
 
+Tests should be run locally before making a PR, and should pass in CI before a PR is merged.
+
 ## Implications for Security
 
  * Where complex data parsing logic is implemented, ensure fuzzing tests are place to improve resilience against malformed payloads.

--- a/REVIEWING.md
+++ b/REVIEWING.md
@@ -8,6 +8,10 @@ This is a _work in progress_ and additions to this list are welcome.
 
 If any of the `.proto` files are changed, then the corresponding Go code should be regenerated in the same PR (`GOPATH=$(go env GOPATH) rake codegen`).
 
+## Implications for Security
+
+ * Where complex data parsing logic is implemented, ensure fuzzing tests are place to improve resilience against malformed payloads.
+
 ## Implications for the Agent
 
 TBD


### PR DESCRIPTION
The `agent-shared-components` team is assigned to review changes to this repo, but has very little experience with the repo and nobody on the team really knows what to look for.

I've written some things down here, but ideally this doc would get filled out a bit more before (or after) this PR lands.