### PR TITLE
[NET-2833] adds fuzz testing on tags

### DIFF
--- a/process/tags_test.go
+++ b/process/tags_test.go
@@ -171,6 +171,18 @@ func TestUnsafeIterationV1(t *testing.T) {
 	})
 }
 
+func FuzzIterateV1(f *testing.F) {
+	f.Add(make([]byte, 6), 1)
+	f.Fuzz(FuzzingIterateV1)
+}
+
+func FuzzingIterateV1(t *testing.T, buffer []byte, tagIndex int) {
+	assert.NotPanics(t, func() {
+		unsafeIterateV1(buffer, tagIndex, func(i, total int, tag []byte) bool { return true })
+	})
+
+}
+
 func BenchmarkTagEncode(b *testing.B) {
 	allTags := readTestTags(b, "testdata/tags.txt")
 

--- a/process/tags_test.go
+++ b/process/tags_test.go
@@ -172,7 +172,15 @@ func TestUnsafeIterationV1(t *testing.T) {
 }
 
 func FuzzIterateV1(f *testing.F) {
-	f.Add(make([]byte, 6), 1)
+	allTags := readTestTags(f, "testdata/tags.txt")
+	t := NewTagEncoder()
+
+	for _, tag := range allTags {
+		_ = t.Encode(tag)
+	}
+	buf := t.Buffer()
+
+	f.Add(buf, 1)
 	f.Fuzz(FuzzingIterateV1)
 }
 

--- a/process/tags_v2.go
+++ b/process/tags_v2.go
@@ -167,7 +167,7 @@ func iterateV2(buffer []byte, tagIndex int, cb func(i, total int, tag string) bo
 }
 
 func unsafeIterateV2(buffer []byte, tagIndex int, cb func(i, total int, tag []byte) bool) {
-	if len(buffer) <= 0 || len(buffer[1:]) < lenUint32 || tagIndex < 0 {
+	if len(buffer) < lenUint32+1 || tagIndex < 0 {
 		return
 	}
 	footerPosition := binary.LittleEndian.Uint32(buffer[1:])

--- a/process/tags_v2.go
+++ b/process/tags_v2.go
@@ -167,7 +167,7 @@ func iterateV2(buffer []byte, tagIndex int, cb func(i, total int, tag string) bo
 }
 
 func unsafeIterateV2(buffer []byte, tagIndex int, cb func(i, total int, tag []byte) bool) {
-	if len(buffer[1:]) < lenUint32 {
+	if len(buffer) <= 0 || len(buffer[1:]) < lenUint32 || tagIndex < 0 {
 		return
 	}
 	footerPosition := binary.LittleEndian.Uint32(buffer[1:])

--- a/process/tags_v2_test.go
+++ b/process/tags_v2_test.go
@@ -37,6 +37,18 @@ func TestUnsafeIterationV2(t *testing.T) {
 	})
 }
 
+func FuzzIterateV2(f *testing.F) {
+	f.Add(make([]byte, 6), 1)
+	f.Fuzz(FuzzingIterateV2)
+}
+
+func FuzzingIterateV2(t *testing.T, buffer []byte, tagIndex int) {
+	assert.NotPanics(t, func() {
+		unsafeIterateV2(buffer, tagIndex, func(i, total int, tag []byte) bool { return true })
+	})
+
+}
+
 func BenchmarkTagEncoders(b *testing.B) {
 	files := []struct {
 		name  string

--- a/process/tags_v2_test.go
+++ b/process/tags_v2_test.go
@@ -38,7 +38,15 @@ func TestUnsafeIterationV2(t *testing.T) {
 }
 
 func FuzzIterateV2(f *testing.F) {
-	f.Add(make([]byte, 6), 1)
+	allTags := readTestTags(f, "testdata/tags.txt")
+	t := NewTagEncoder()
+
+	for _, tag := range allTags {
+		_ = t.Encode(tag)
+	}
+	buf := t.Buffer()
+
+	f.Add(buf, 1)
 	f.Fuzz(FuzzingIterateV2)
 }
 


### PR DESCRIPTION
This PR adds fuzz testing for the unsafe iteration of tags. `fuzz` mutates test inputs to find edge cases. After running the fuzz tests I also added checks `unsafeIterateV2`. 