### PR TITLE
Add a retract for v5.0.59

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,3 +14,5 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 )
+
+retract v5.0.59 // Was accidentally deployed in place of v5.0.49


### PR DESCRIPTION
When creating a release for v5.0.49 a release was accidentally create for v5.0.59. Adding a retract to go.mod so depdency managers don't try to upgrade to this version

Reviewers: please see the [review guidelines](https://github.com/DataDog/agent-payload/blob/master/REVIEWING.md).
