### PR TITLE
Regen from master due to Go version chnge

### DIFF
--- a/process/agent.pb.go
+++ b/process/agent.pb.go
@@ -12661,11 +12661,14 @@ type KafkaStats struct {
 	// a protobuf encoded sketch of all the requests in a KafkaStats, in nanoseconds.
 	// this will be nil if count == 1
 	// To decode:
-	//    use a protobuf library to decode this into a github.com/DataDog/sketches-go/ddsketch/pb/sketchpb.DDSketch
+	//
+	//	use a protobuf library to decode this into a github.com/DataDog/sketches-go/ddsketch/pb/sketchpb.DDSketch
+	//
 	// then call github.com/DataDog/sketches-go/ddsketch.FromProto
 	// To encode:
-	//    create a github.com/DataDog/sketches-go/ddsketch.DDSketch
-	//    call ToProto() and then run through a protobuf encoder
+	//
+	//	create a github.com/DataDog/sketches-go/ddsketch.DDSketch
+	//	call ToProto() and then run through a protobuf encoder
 	Latencies []byte `protobuf:"bytes,2,opt,name=latencies,proto3" json:"latencies,omitempty"`
 	// if the KafkaStats has a single sample, this field will be the latency (in nanoseconds) of the only sample.
 	// this is purely to avoid the overhead of having single entry sketches.


### PR DESCRIPTION
### What does this PR do?

Re-run `rake codegen` due to concurrent of #311 and #302

### Motivation

Fix CI.

### Additional Notes

Go version has impact on generated spaces/newlines.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist

Reviewers: please see the [review guidelines](https://github.com/DataDog/agent-payload/blob/master/REVIEWING.md).
