### PR TITLE
Update container-app to use newer include files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -149,13 +149,13 @@ BASH
 
 
       echo "Generating contlcycle proto"
-      PATH=#{toolchain_bin_dir} #{protoc_binary} --proto_path=#{toolchain_legacy_include_dir}:. --go_out=$GOPATH/src proto/contlcycle/contlcycle.proto
+      PATH=#{toolchain_bin_dir} #{protoc_binary} --proto_path=#{toolchain_include_dir}:. --go_out=$GOPATH/src proto/contlcycle/contlcycle.proto
 
       echo "Generating kubernetes autoscaling proto"
-      PATH=#{toolchain_bin_dir} #{protoc_binary} --proto_path=$GOPATH/src:#{toolchain_legacy_include_dir}:. --go_out=$GOPATH/src --jsonschema_out=type_names_with_no_package:jsonschema proto/autoscaling/kubernetes/autoscaling.proto
+      PATH=#{toolchain_bin_dir} #{protoc_binary} --proto_path=$GOPATH/src:#{toolchain_include_dir}:. --go_out=$GOPATH/src --jsonschema_out=type_names_with_no_package:jsonschema proto/autoscaling/kubernetes/autoscaling.proto
 
       echo "Generating contimage proto"
-      PATH=#{toolchain_bin_dir}  #{protoc_binary} --proto_path=#{toolchain_legacy_include_dir}:. --go_out=$GOPATH/src proto/contimage/contimage.proto
+      PATH=#{toolchain_bin_dir}  #{protoc_binary} --proto_path=#{toolchain_include_dir}:. --go_out=$GOPATH/src proto/contimage/contimage.proto
 
       echo "Generating sbom proto"
       PATH=#{toolchain_bin_dir} #{protoc_binary} --proto_path=#{toolchain_include_dir}:. --go_out=$GOPATH/src proto/deps/github.com/CycloneDX/specification/schema/bom-1.4.proto

--- a/autoscaling/kubernetes/autoscaling.pb.go
+++ b/autoscaling/kubernetes/autoscaling.pb.go
@@ -8,9 +8,9 @@ package kubernetes
 
 import (
 	_ "github.com/chrusty/protoc-gen-jsonschema"
-	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 )
@@ -274,8 +274,8 @@ type WorkloadHorizontalData struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Timestamp *timestamp.Timestamp `protobuf:"bytes,1,opt,name=timestamp,proto3" json:"timestamp,omitempty"`      // Timestamp is the time the values were generated
-	Replicas  *int32               `protobuf:"varint,2,opt,name=replicas,proto3,oneof" json:"replicas,omitempty"` // Replicas is the number of replicas the workload should have
+	Timestamp *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=timestamp,proto3" json:"timestamp,omitempty"`      // Timestamp is the time the values were generated
+	Replicas  *int32                 `protobuf:"varint,2,opt,name=replicas,proto3,oneof" json:"replicas,omitempty"` // Replicas is the number of replicas the workload should have
 }
 
 func (x *WorkloadHorizontalData) Reset() {
@@ -310,7 +310,7 @@ func (*WorkloadHorizontalData) Descriptor() ([]byte, []int) {
 	return file_proto_autoscaling_kubernetes_autoscaling_proto_rawDescGZIP(), []int{4}
 }
 
-func (x *WorkloadHorizontalData) GetTimestamp() *timestamp.Timestamp {
+func (x *WorkloadHorizontalData) GetTimestamp() *timestamppb.Timestamp {
 	if x != nil {
 		return x.Timestamp
 	}
@@ -392,8 +392,8 @@ type WorkloadVerticalData struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Timestamp *timestamp.Timestamp  `protobuf:"bytes,1,opt,name=timestamp,proto3" json:"timestamp,omitempty"` // Timestamp is the time the values were generated
-	Resources []*ContainerResources `protobuf:"bytes,2,rep,name=resources,proto3" json:"resources,omitempty"` // Resources is the list of resources for the workload
+	Timestamp *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=timestamp,proto3" json:"timestamp,omitempty"` // Timestamp is the time the values were generated
+	Resources []*ContainerResources  `protobuf:"bytes,2,rep,name=resources,proto3" json:"resources,omitempty"` // Resources is the list of resources for the workload
 }
 
 func (x *WorkloadVerticalData) Reset() {
@@ -428,7 +428,7 @@ func (*WorkloadVerticalData) Descriptor() ([]byte, []int) {
 	return file_proto_autoscaling_kubernetes_autoscaling_proto_rawDescGZIP(), []int{6}
 }
 
-func (x *WorkloadVerticalData) GetTimestamp() *timestamp.Timestamp {
+func (x *WorkloadVerticalData) GetTimestamp() *timestamppb.Timestamp {
 	if x != nil {
 		return x.Timestamp
 	}
@@ -708,7 +708,7 @@ var file_proto_autoscaling_kubernetes_autoscaling_proto_goTypes = []interface{}{
 	(*WorkloadVerticalData)(nil),            // 6: datadog.autoscaling.kubernetes.WorkloadVerticalData
 	(*ContainerResources)(nil),              // 7: datadog.autoscaling.kubernetes.ContainerResources
 	(*ContainerResources_ResourceList)(nil), // 8: datadog.autoscaling.kubernetes.ContainerResources.ResourceList
-	(*timestamp.Timestamp)(nil),             // 9: google.protobuf.Timestamp
+	(*timestamppb.Timestamp)(nil),           // 9: google.protobuf.Timestamp
 }
 var file_proto_autoscaling_kubernetes_autoscaling_proto_depIdxs = []int32{
 	2,  // 0: datadog.autoscaling.kubernetes.WorkloadValuesList.values:type_name -> datadog.autoscaling.kubernetes.WorkloadValues

--- a/contimage/contimage.pb.go
+++ b/contimage/contimage.pb.go
@@ -7,9 +7,9 @@
 package contimage
 
 import (
-	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 	reflect "reflect"
 	sync "sync"
 )
@@ -110,8 +110,8 @@ type ContainerImage struct {
 	RepoDigests []string                              `protobuf:"bytes,8,rep,name=repo_digests,json=repoDigests,proto3" json:"repo_digests,omitempty"`
 	Os          *ContainerImage_OperatingSystem       `protobuf:"bytes,9,opt,name=os,proto3" json:"os,omitempty"`
 	Layers      []*ContainerImage_ContainerImageLayer `protobuf:"bytes,10,rep,name=layers,proto3" json:"layers,omitempty"`
-	BuiltAt     *timestamp.Timestamp                  `protobuf:"bytes,11,opt,name=builtAt,proto3" json:"builtAt,omitempty"`
-	PublishedAt *timestamp.Timestamp                  `protobuf:"bytes,13,opt,name=publishedAt,proto3,oneof" json:"publishedAt,omitempty"`
+	BuiltAt     *timestamppb.Timestamp                `protobuf:"bytes,11,opt,name=builtAt,proto3" json:"builtAt,omitempty"`
+	PublishedAt *timestamppb.Timestamp                `protobuf:"bytes,13,opt,name=publishedAt,proto3,oneof" json:"publishedAt,omitempty"`
 }
 
 func (x *ContainerImage) Reset() {
@@ -223,14 +223,14 @@ func (x *ContainerImage) GetLayers() []*ContainerImage_ContainerImageLayer {
 	return nil
 }
 
-func (x *ContainerImage) GetBuiltAt() *timestamp.Timestamp {
+func (x *ContainerImage) GetBuiltAt() *timestamppb.Timestamp {
 	if x != nil {
 		return x.BuiltAt
 	}
 	return nil
 }
 
-func (x *ContainerImage) GetPublishedAt() *timestamp.Timestamp {
+func (x *ContainerImage) GetPublishedAt() *timestamppb.Timestamp {
 	if x != nil {
 		return x.PublishedAt
 	}
@@ -385,11 +385,11 @@ type ContainerImage_ContainerImageLayer_History struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Created    *timestamp.Timestamp `protobuf:"bytes,1,opt,name=created,proto3" json:"created,omitempty"`
-	CreatedBy  string               `protobuf:"bytes,2,opt,name=createdBy,proto3" json:"createdBy,omitempty"`
-	Author     string               `protobuf:"bytes,3,opt,name=author,proto3" json:"author,omitempty"`
-	Comment    string               `protobuf:"bytes,4,opt,name=comment,proto3" json:"comment,omitempty"`
-	EmptyLayer bool                 `protobuf:"varint,5,opt,name=emptyLayer,proto3" json:"emptyLayer,omitempty"`
+	Created    *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=created,proto3" json:"created,omitempty"`
+	CreatedBy  string                 `protobuf:"bytes,2,opt,name=createdBy,proto3" json:"createdBy,omitempty"`
+	Author     string                 `protobuf:"bytes,3,opt,name=author,proto3" json:"author,omitempty"`
+	Comment    string                 `protobuf:"bytes,4,opt,name=comment,proto3" json:"comment,omitempty"`
+	EmptyLayer bool                   `protobuf:"varint,5,opt,name=emptyLayer,proto3" json:"emptyLayer,omitempty"`
 }
 
 func (x *ContainerImage_ContainerImageLayer_History) Reset() {
@@ -424,7 +424,7 @@ func (*ContainerImage_ContainerImageLayer_History) Descriptor() ([]byte, []int) 
 	return file_proto_contimage_contimage_proto_rawDescGZIP(), []int{1, 1, 0}
 }
 
-func (x *ContainerImage_ContainerImageLayer_History) GetCreated() *timestamp.Timestamp {
+func (x *ContainerImage_ContainerImageLayer_History) GetCreated() *timestamppb.Timestamp {
 	if x != nil {
 		return x.Created
 	}
@@ -567,7 +567,7 @@ var file_proto_contimage_contimage_proto_goTypes = []interface{}{
 	(*ContainerImage_OperatingSystem)(nil),             // 2: datadog.contimage.ContainerImage.OperatingSystem
 	(*ContainerImage_ContainerImageLayer)(nil),         // 3: datadog.contimage.ContainerImage.ContainerImageLayer
 	(*ContainerImage_ContainerImageLayer_History)(nil), // 4: datadog.contimage.ContainerImage.ContainerImageLayer.History
-	(*timestamp.Timestamp)(nil),                        // 5: google.protobuf.Timestamp
+	(*timestamppb.Timestamp)(nil),                      // 5: google.protobuf.Timestamp
 }
 var file_proto_contimage_contimage_proto_depIdxs = []int32{
 	1, // 0: datadog.contimage.ContainerImagePayload.images:type_name -> datadog.contimage.ContainerImage


### PR DESCRIPTION

### What does this PR do?

This updates contlcycle, autoscaling, and contimage to generate their payloads using non-deprecated shared protobuf definitions. This will help us reduce some cruft in the build script.

The changes are wire compatible, but the generated go code might not compile cleanly into the agent/backend.

See for context
* https://github.com/DataDog/agent-payload/pull/337
* https://github.com/DataDog/agent-payload/pull/342

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change (if applicable)?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist

Reviewers: please see the [review guidelines](https://github.com/DataDog/agent-payload/blob/master/REVIEWING.md).
