### PR TITLE
Allow rake to remove toolchaing, clean before testing

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -33,6 +33,9 @@ protoc_jsonschema_version="73d5723"
 namespace :codegen do
   task :clean do
       sh "rm -rf #{gogo_dir}"
+      if Dir.exist?(toolchain_dir)
+          sh "chmod u+w -R #{toolchain_dir}"
+      end
       sh "rm -rf #{toolchain_dir}"
   end
 
@@ -174,7 +177,7 @@ task :deps do
 end
 
 desc "Run tests"
-task :test do
+task :test => ['codegen:clean'] do
   cmd = "go list ./... | grep -v vendor | xargs go test -v "
   sh cmd
 end


### PR DESCRIPTION
I've hit two problems:
1. Running `rake` then `rake test` would fail[1]. To address this I run `codegen:clean` before test
2. Runig `rake codegen:clean` would fail[2]. To address this I add write permission to the toolchain dir before attemmpting to remove it.

[1]
```bash
$ rake test
  2 go list ./... | grep -v vendor | xargs go test -v
  3 pattern ./...: directory toolchains/pkg/mod/github.com/fatih/camelcase@v1.0.0 outside main module or its selected dependencies
```
[2]
```bash
$ rake codegen:clean
rm -rf /Users/joachim.bartosik/go/src/github.com/DataDog/agent-payload/toolchains/gogo
rm -rf /Users/joachim.bartosik/go/src/github.com/DataDog/agent-payload/toolchains
rm: cannot remove '/Users/joachim.bartosik/go/src/github.com/DataDog/agent-payload/toolchains/pkg/mod/github.com/envoyproxy/protoc-gen-validate@v0.10.1/main.go': Permission denied
rake aborted!
Command failed with status (1): [rm -rf /Users/joachim.bartosik/go/src/gith...]
/Users/joachim.bartosik/go/src/github.com/DataDog/agent-payload/Rakefile:36:in `block (2 levels) in <top (required)>'
Tasks: TOP => codegen:clean
(See full trace by running task with --trace)
```

### Motivation

I want to run `rake test` and have it work.

Reviewers: please see the [review guidelines](https://github.com/DataDog/agent-payload/blob/master/REVIEWING.md).
