### PR TITLE
Update protoc-gen-gostreamer

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -112,7 +112,7 @@ BASH
       echo "Generating process proto (go)"
       PATH=#{toolchain_bin_dir} #{protoc_binary} --proto_path=#{toolchain_include_dir}:#{gogo_include}:. --gogofaster_out=$GOPATH/src proto/process/*.proto
 
-      GOPATH=#{toolchain_dir} go install github.com/leeavital/protoc-gen-gostreamer@v0.1.0
+      GOPATH=#{toolchain_dir} go install github.com/DataDog/protoc-gen-gostreamer@v0.2.0
       PATH=#{toolchain_bin_dir} #{protoc_binary} --proto_path=$GOPATH/src:#{gogo_dir}/src:.  --gostreamer_out=$GOPATH/src proto/process/*.proto
       mv v5/process/proto/process/*.go process
 

--- a/process/agent.proto_builder.go
+++ b/process/agent.proto_builder.go
@@ -3269,12 +3269,12 @@ func (x *ProcessNetworksBuilder) Reset(writer io.Writer) {
 	x.writer = writer
 }
 func (x *ProcessNetworksBuilder) SetConnectionRate(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x9)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0xd)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *ProcessNetworksBuilder) SetBytesRate(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x11)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x15)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
@@ -3356,7 +3356,7 @@ func (x *ContainerBuilder) SetImage(v string) {
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerBuilder) SetCpuLimit(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x29)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x2d)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
@@ -3387,12 +3387,12 @@ func (x *ContainerBuilder) SetCreated(v int64) {
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerBuilder) SetRbps(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x59)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x5d)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerBuilder) SetWbps(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x61)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x65)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
@@ -3403,37 +3403,37 @@ func (x *ContainerBuilder) SetKey(v uint32) {
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerBuilder) SetNetRcvdPs(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x71)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x75)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerBuilder) SetNetSentPs(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x79)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x7d)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerBuilder) SetNetRcvdBps(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x81)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x85)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerBuilder) SetNetSentBps(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x89)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x8d)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerBuilder) SetUserPct(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x91)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x95)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerBuilder) SetSystemPct(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x99)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x9d)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerBuilder) SetTotalPct(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0xa1)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0xa5)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
@@ -3508,7 +3508,7 @@ func (x *ContainerBuilder) SetMemUsage(v uint64) {
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerBuilder) SetCpuUsageNs(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0xf9)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0xfd)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
@@ -3519,7 +3519,7 @@ func (x *ContainerBuilder) SetMemAccounted(v uint64) {
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerBuilder) SetCpuRequest(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x109)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x10d)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
@@ -3659,12 +3659,12 @@ func (x *ProcessStatBuilder) SetContainerHealth(v uint64) {
 	}
 }
 func (x *ProcessStatBuilder) SetContainerRbps(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x81)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x85)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *ProcessStatBuilder) SetContainerWbps(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x89)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x8d)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
@@ -3675,22 +3675,22 @@ func (x *ProcessStatBuilder) SetContainerKey(v uint32) {
 	x.writer.Write(x.scratch)
 }
 func (x *ProcessStatBuilder) SetContainerNetRcvdPs(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0xa1)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0xa5)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *ProcessStatBuilder) SetContainerNetSentPs(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0xa9)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0xad)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *ProcessStatBuilder) SetContainerNetRcvdBps(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0xb1)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0xb5)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *ProcessStatBuilder) SetContainerNetSentBps(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0xb9)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0xbd)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
@@ -3851,22 +3851,22 @@ func (x *ContainerStatBuilder) SetId(v string) {
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerStatBuilder) SetUserPct(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x11)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x15)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerStatBuilder) SetSystemPct(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x19)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x1d)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerStatBuilder) SetTotalPct(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x21)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x25)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerStatBuilder) SetCpuLimit(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x29)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x2d)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
@@ -3889,32 +3889,32 @@ func (x *ContainerStatBuilder) SetMemLimit(v uint64) {
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerStatBuilder) SetRbps(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x49)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x4d)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerStatBuilder) SetWbps(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x51)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x55)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerStatBuilder) SetNetRcvdPs(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x59)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x5d)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerStatBuilder) SetNetSentPs(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x61)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x65)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerStatBuilder) SetNetRcvdBps(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x69)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x6d)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerStatBuilder) SetNetSentBps(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x71)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x75)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
@@ -3971,7 +3971,7 @@ func (x *ContainerStatBuilder) SetMemUsage(v uint64) {
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerStatBuilder) SetCpuUsageNs(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0xb9)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0xbd)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
@@ -3982,7 +3982,7 @@ func (x *ContainerStatBuilder) SetMemAccounted(v uint64) {
 	x.writer.Write(x.scratch)
 }
 func (x *ContainerStatBuilder) SetCpuRequest(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0xc9)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0xcd)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
@@ -4105,22 +4105,22 @@ func (x *IOStatBuilder) Reset(writer io.Writer) {
 	x.writer = writer
 }
 func (x *IOStatBuilder) SetReadRate(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x9)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0xd)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *IOStatBuilder) SetWriteRate(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x11)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x15)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *IOStatBuilder) SetReadBytesRate(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x19)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x1d)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *IOStatBuilder) SetWriteBytesRate(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x21)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x25)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
@@ -4212,17 +4212,17 @@ func (x *CPUStatBuilder) SetLastCpu(v string) {
 	x.writer.Write(x.scratch)
 }
 func (x *CPUStatBuilder) SetTotalPct(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x11)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x15)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *CPUStatBuilder) SetUserPct(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x19)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x1d)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
 func (x *CPUStatBuilder) SetSystemPct(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x21)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x25)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }
@@ -4283,7 +4283,7 @@ func (x *SingleCPUStatBuilder) SetName(v string) {
 	x.writer.Write(x.scratch)
 }
 func (x *SingleCPUStatBuilder) SetTotalPct(v float32) {
-	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x11)
+	x.scratch = protowire.AppendVarint(x.scratch[:0], 0x15)
 	x.scratch = protowire.AppendFixed32(x.scratch, math.Float32bits(v))
 	x.writer.Write(x.scratch)
 }


### PR DESCRIPTION

### What does this PR do?


This uses a new datadog-managed package for protoc-gen-gostreamer. 

The generated code uses different proto tags for floating point numbers. This is expected because  v0.2.0 fixed a bug where floats were represented as varints.


<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change (if applicable)?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist

Reviewers: please see the [review guidelines](https://github.com/DataDog/agent-payload/blob/master/REVIEWING.md).
