### PR TITLE
Update CODEOWNERS to include ecs-experiences

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,8 +7,8 @@ metrics/                    @DataDog/agent-metric-pipelines
 proto/metrics/              @DataDog/agent-metric-pipelines
 logs/                       @DataDog/agent-log-pipelines
 proto/logs/                 @DataDog/agent-log-pipelines
-process/                    @DataDog/kubernetes-experiences @DataDog/container-experiences
-proto/process/              @DataDog/kubernetes-experiences @DataDog/container-experiences
+process/                    @DataDog/kubernetes-experiences @DataDog/container-experiences @DataDog/ecs-experiences
+proto/process/              @DataDog/kubernetes-experiences @DataDog/container-experiences @DataDog/ecs-experiences
 process/connections.*       @DataDog/cloud-network-monitoring @DataDog/ebpf-platform @DataDog/universal-service-monitoring
 proto/process/connections.* @DataDog/cloud-network-monitoring @DataDog/ebpf-platform @DataDog/universal-service-monitoring
 contlcycle/                 @DataDog/container-integrations


### PR DESCRIPTION
### What does this PR do?
Adds team ecs-experiences as code owners of `proto/process/` and `process`

### Motivation

The ecs-experiences team owns ECS related proto definitions in these files.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change (if applicable)?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist

Reviewers: please see the [review guidelines](https://github.com/DataDog/agent-payload/blob/master/REVIEWING.md).
