### PR TITLE
feat(proto): add proto_library BUILD target for healthplatform

### DIFF
--- a/proto/healthplatform/BUILD.bazel
+++ b/proto/healthplatform/BUILD.bazel
@@ -3,6 +3,8 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "healthplatform_proto",
     srcs = ["healthplatform.proto"],
+    strip_import_prefix = "/proto",
+    import_prefix = "datadog",
     deps = ["@protobuf//:struct_proto"],
     visibility = ["//visibility:public"],
 )

--- a/proto/healthplatform/BUILD.bazel
+++ b/proto/healthplatform/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+    name = "healthplatform_proto",
+    srcs = ["healthplatform.proto"],
+    deps = ["@protobuf//:struct_proto"],
+    visibility = ["//visibility:public"],
+)


### PR DESCRIPTION
## What does this PR do?

Adds a Bazel `proto_library` target for `proto/healthplatform/healthplatform.proto`, following the same pattern already used by `proto/process/BUILD.bazel` and `proto/autoscaling/kubernetes/BUILD.bazel`.

## Motivation

This allows consumers — specifically [`datadog-agent`'s `pkg/proto/datadog/api/v1/api.proto`](https://github.com/DataDog/datadog-agent/pull/50950) — to import `healthplatform.proto` directly from this module via a Bazel dep rather than vendoring a copy or using `google.protobuf.Any` as an escape hatch.

Once this lands, datadog-agent can reference `@agent_payload//proto/healthplatform:healthplatform_proto` in its `proto_library` dep and import `datadog/healthplatform/healthplatform.proto` directly in `api.proto`.