### PR TITLE
fix(bazel): replace deprecated @rules_proto with @protobuf for all proto_library targets

### DIFF
--- a/proto/autoscaling/kubernetes/BUILD.bazel
+++ b/proto/autoscaling/kubernetes/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "kubernetes_autoscaling_proto",

--- a/proto/autoscaling/kubernetes/BUILD.bazel
+++ b/proto/autoscaling/kubernetes/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "kubernetes_autoscaling_proto",

--- a/proto/healthplatform/BUILD.bazel
+++ b/proto/healthplatform/BUILD.bazel
@@ -5,6 +5,6 @@ proto_library(
     srcs = ["healthplatform.proto"],
     strip_import_prefix = "/proto",
     import_prefix = "datadog",
-    deps = ["@protobuf//:struct_proto"],
+    deps = ["@com_google_protobuf//:struct_proto"],
     visibility = ["//visibility:public"],
 )

--- a/proto/healthplatform/BUILD.bazel
+++ b/proto/healthplatform/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "healthplatform_proto",

--- a/proto/healthplatform/BUILD.bazel
+++ b/proto/healthplatform/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "healthplatform_proto",

--- a/proto/process/BUILD.bazel
+++ b/proto/process/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "agent_proto",

--- a/proto/process/BUILD.bazel
+++ b/proto/process/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "agent_proto",


### PR DESCRIPTION
## Summary

Replace `load("@rules_proto//proto:defs.bzl", "proto_library")` with `load("@protobuf//bazel:proto_library.bzl", "proto_library")` in all three proto BUILD files:

- `proto/healthplatform/BUILD.bazel`
- `proto/process/BUILD.bazel`
- `proto/autoscaling/kubernetes/BUILD.bazel`

`@rules_proto` is deprecated and not available in bzlmod-based Bazel setups. The modern equivalent is `@protobuf//bazel:proto_library.bzl`.

## Context

This is blocking [DataDog/datadog-agent#50950](https://github.com/DataDog/datadog-agent/pull/50950) from enforcing a typed `datadog.healthplatform.Issue` field in `ReportHealthIssueRequest` instead of `google.protobuf.Any`. The datadog-agent repo uses bzlmod and cannot load `@rules_proto`, so `@com_github_datadog_agent_payload_v5//proto/healthplatform:healthplatform_proto` is currently unusable as a `proto_library` dep.

## Test plan

- [ ] Verify `bazel build //proto/healthplatform:healthplatform_proto` passes
- [ ] Verify `bazel build //proto/process:agent_proto` passes
- [ ] Verify `bazel build //proto/autoscaling/kubernetes:kubernetes_autoscaling_proto` passes