### PR TITLE
chore: add fleet-remediation as CODEOWNERS co-owner alongside agent-health

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,7 +25,7 @@ autoscaling/                @DataDog/container-autoscaling
 proto/autoscaling/          @DataDog/container-autoscaling
 jsonschema/                 @DataDog/container-autoscaling
 kubeactions/                @DataDog/container-integrations
-healthplatform/             @DataDog/agent-health
-proto/healthplatform/       @DataDog/agent-health
+healthplatform/             @DataDog/fleet-remediation
+proto/healthplatform/       @DataDog/fleet-remediation
 statefulpb/                 @DataDog/agent-log-pipelines @DataDog/event-platform-intake
 proto/logsstateful/         @DataDog/agent-log-pipelines @DataDog/event-platform-intake

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,7 +25,7 @@ autoscaling/                @DataDog/container-autoscaling
 proto/autoscaling/          @DataDog/container-autoscaling
 jsonschema/                 @DataDog/container-autoscaling
 kubeactions/                @DataDog/container-integrations
-healthplatform/             @DataDog/fleet-remediation
-proto/healthplatform/       @DataDog/fleet-remediation
+healthplatform/             @DataDog/agent-health @DataDog/fleet-remediation
+proto/healthplatform/       @DataDog/agent-health @DataDog/fleet-remediation
 statefulpb/                 @DataDog/agent-log-pipelines @DataDog/event-platform-intake
 proto/logsstateful/         @DataDog/agent-log-pipelines @DataDog/event-platform-intake


### PR DESCRIPTION
### What does this PR do?

Adds `@DataDog/fleet-remediation` as a co-owner alongside the existing `@DataDog/agent-health` for `healthplatform/` and `proto/healthplatform/` in CODEOWNERS.

### Motivation

The `agent-health` team is being renamed to `fleet-remediation`. Rather than a hard cutover, ownership is rolling out progressively — both teams are listed as owners until the transition is confirmed, then `agent-health` will be removed in a follow-up PR.

### Additional Notes

Part of a coordinated rollout across agent-payload, datadog-agent, dd-source, logs-backend, and web-ui. The `@DataDog/fleet-remediation` GitHub team did not exist yet at the time of this PR — please confirm it exists before merging.

### Possible Drawbacks / Trade-offs

None — text-only ownership metadata change.

### Describe how to test/QA your changes

N/A — CODEOWNERS metadata only.