### PR TITLE
chore: remove agent-health, keep fleet-remediation as sole CODEOWNERS owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,7 +25,7 @@ autoscaling/                @DataDog/container-autoscaling
 proto/autoscaling/          @DataDog/container-autoscaling
 jsonschema/                 @DataDog/container-autoscaling
 kubeactions/                @DataDog/container-integrations
-healthplatform/             @DataDog/agent-health @DataDog/fleet-remediation
-proto/healthplatform/       @DataDog/agent-health @DataDog/fleet-remediation
+healthplatform/             @DataDog/fleet-remediation
+proto/healthplatform/       @DataDog/fleet-remediation
 statefulpb/                 @DataDog/agent-log-pipelines @DataDog/event-platform-intake
 proto/logsstateful/         @DataDog/agent-log-pipelines @DataDog/event-platform-intake


### PR DESCRIPTION
### What does this PR do?

Removes `@DataDog/agent-health` from CODEOWNERS for `healthplatform/` and `proto/healthplatform/`, leaving `@DataDog/fleet-remediation` as the sole owner.

### Motivation

The `agent-health` team has been renamed to `fleet-remediation`. The progressive co-owner rollout (#497) has run its course — this completes the cutover.

### Additional Notes

Part of a coordinated cutover across agent-payload, datadog-agent, dd-source, logs-backend, and web-ui.

### Possible Drawbacks / Trade-offs

None — text-only ownership metadata change.

### Describe how to test/QA your changes

N/A — CODEOWNERS metadata only.