### PR TITLE
Remove github.com/DataDog/zstd_0 dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.24.0
 require (
 	github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a
 	github.com/DataDog/zstd v1.4.8
-	github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f
 	github.com/chrusty/protoc-gen-jsonschema v0.0.0-20240212064413-73d5723042b8
 	github.com/gogo/protobuf v1.3.2
 	github.com/klauspost/compress v1.18.0

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a h1:m9REhmyaWD5YJ0P53y
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
 github.com/DataDog/zstd v1.4.8 h1:Rpmta4xZ/MgZnriKNd24iZMhGpP5dvUcs/uqfBapKZY=
 github.com/DataDog/zstd v1.4.8/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
-github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f h1:5Vuo4niPKFkfwW55jV4vY0ih3VQ9RaQqeqY67fvRn8A=
-github.com/DataDog/zstd_0 v0.0.0-20210310093942-586c1286621f/go.mod h1:oXfOhM/Kr8OvqS6tVqJwxPBornV0yrx3bc+l0BDr7PQ=
 github.com/alecthomas/jsonschema v0.0.0-20210918223802-a1d3f4b43d7b/go.mod h1:/n6+1/DWPltRLWL/VKyUxg6tzsl5kHUCcraimt4vr60=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/process/compress.go
+++ b/process/compress.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 
 	"github.com/DataDog/zstd"
-	"github.com/DataDog/zstd_0"
 
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/gogo/protobuf/proto"
@@ -33,7 +32,7 @@ func unmarshal(enc MessageEncoding, body []byte, m proto.Message) error {
 			}
 			d, err = decoder.DecodeAll(body, nil)
 		} else {
-			d, err = zstd_0.Decompress(nil, body)
+			return fmt.Errorf("unsupported encoding: MessageEncodingZstdPB is no longer supported")
 		}
 		if err != nil {
 			return err
@@ -93,10 +92,7 @@ func EncodeMessage(m Message) ([]byte, error) {
 				return nil, err
 			}
 		} else {
-			p, err = zstd_0.Compress(nil, pb)
-			if err != nil {
-				return nil, err
-			}
+			return nil, fmt.Errorf("unsupported encoding: MessageEncodingZstdPB is no longer supported")
 		}
 	default:
 		return nil, fmt.Errorf("unknown message encoding: %d", m.Header.Encoding)

--- a/process/message_test.go
+++ b/process/message_test.go
@@ -9,27 +9,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// TestDecodeZstd05Payload ensures backward compatibility with our intake
+// TestDecodeZstd05Payload ensures MessageEncodingZstdPB payloads fail to
+// decode now that the vulnerable zstd_0 dependency has been removed.
 func TestDecodeZstd05Payload(t *testing.T) {
 	file := "testdata/test_zstd.0.5.dump"
-	expected := Message{
-		Header: MessageHeader{
-			Version:  MessageV3,
-			Encoding: MessageEncodingZstdPB,
-			Type:     TypeCollectorProc,
-		},
-		Body: &CollectorProc{
-			HostName: "test",
-		},
-	}
 
 	raw, err := ioutil.ReadFile(file)
 	assert.NoError(t, err)
 
-	msg, err := DecodeMessage(raw)
-	assert.NoError(t, err)
-
-	assert.Equal(t, expected, msg)
+	_, err = DecodeMessage(raw)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported encoding")
 }
 
 func TestMessageTypeString(t *testing.T) {
@@ -76,7 +66,6 @@ func TestManifestPayloadAllEncodings_CGO(t *testing.T) {
 	}{
 		{"Protobuf", MessageEncodingProtobuf},
 		{"JSON", MessageEncodingJSON},
-		{"ZstdPB", MessageEncodingZstdPB},
 		{"Zstd1xPB", MessageEncodingZstd1xPB},
 		{"ZstdPBxNoCgo", MessageEncodingZstdPBxNoCgo},
 	}
@@ -113,4 +102,23 @@ func TestManifestPayloadAllEncodings_CGO(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestZstdPBUnsupported_CGO ensures MessageEncodingZstdPB is rejected now
+// that the vulnerable zstd_0 dependency has been removed.
+func TestZstdPBUnsupported_CGO(t *testing.T) {
+	message := Message{
+		Header: MessageHeader{
+			Version:  MessageV3,
+			Encoding: MessageEncodingZstdPB,
+			Type:     TypeCollectorManifest,
+		},
+		Body: &CollectorManifest{
+			HostName: "test",
+		},
+	}
+
+	_, err := EncodeMessage(message)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported encoding")
 }


### PR DESCRIPTION
### What does this PR do?

Removes zstd_0 from this project.

### Motivation

zstd_0 is an abandoned fork of an old zstd version with known memory safety vulnerabilities. MessageEncodingZstdPB now returns an unsupported-encoding error on encode/decode, matching the behavior already used by the no-cgo build.

### Additional Notes

Once merged we need to bump the one found in the Datadog Agent to the latest version of this project.

### Possible Drawbacks / Trade-offs

It will now error if anyone uses zstd_0.
